### PR TITLE
Arakoon 347

### DIFF
--- a/README
+++ b/README
@@ -35,8 +35,12 @@ messaging_port = 4010
 home = /tmp
 log_level = info  
 
+Debug sections:
 
-Start the node
+Current logging sections are: paxos,client_protocl,tcp_messaging. 
+Environment variable LWT_LOG='paxos -> info;client_protocl ->debug; * -> error' can help to choose the desired level for each section.All sections are initialzed by default to debug.
+
+Start the node:
 
 $> ./arakoon.native -config single.ini --node arakoon_0
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+arakoon (1.5.0) unstable; urgency=low
+  * new upstream version
+
+ -- Romain Slootmaekers <romain@incubaid.com>  Fri, 18 Jan 2013 14:08:45 +0100
+
 arakoon (1.4.1) unstable; urgency=low
   * new upstream version
 

--- a/src/client/client_protocol.ml
+++ b/src/client/client_protocol.ml
@@ -32,6 +32,10 @@ open Statistics
 open Ncfg
 open Client_cfg
 
+let _s_ = string_option2s
+let section = Lwt_log.Section.make "client_protocol"
+(*let () = Lwt_log.Section.set_level section Lwt_log.Debug*)
+
 let read_command (ic,oc) =
   Llio.input_int32 ic >>= fun masked ->
   let magic = Int32.logand masked _MAGIC in
@@ -57,27 +61,30 @@ let read_command (ic,oc) =
   end
 
 
-let response_ok_unit oc =
-  Lwt_log.debug "ok_unit back to client" >>= fun () ->
+let response_ok_unit cid oc =
+  Lwt_log.debug_f ~section  "[connection:%i] ok_unit back to client" cid >>= fun () ->
   Llio.output_int32 oc 0l >>= fun () ->
   Lwt.return false
 
-let response_ok_int64 oc i64 =
+let response_ok_int64 cid oc i64 =
+  Lwt_log.debug_f ~section "[connection:%i] ok_int64 back to client" cid >>= fun () ->
   Llio.output_int32 oc 0l >>= fun () ->
   Llio.output_int64 oc i64 >>= fun () ->
   Lwt.return false
 
-let response_rc_string oc rc string =
+let response_rc_string cid oc rc string =
+  Lwt_log.debug_f ~section "[connection:%i] ok_rc back to client" cid >>= fun () ->
   Llio.output_int32 oc rc >>= fun () ->
   Llio.output_string oc string >>= fun () ->
   Lwt.return false
 
-let response_rc_bool oc rc b =
+let response_rc_bool cid oc rc b =
+  Lwt_log.debug_f ~section "[connection:%i] ok_rc_bool back to client" cid >>= fun () ->
   Llio.output_int32 oc rc >>= fun () ->
   Llio.output_bool oc b >>= fun () ->
   Lwt.return false
 
-let handle_exception oc exn=
+let handle_exception cid oc exn=
   let rc, msg, is_fatal, close_socket = match exn with
   | XException(Arakoon_exc.E_NOT_FOUND, msg) -> Arakoon_exc.E_NOT_FOUND,msg, false, false
   | XException(Arakoon_exc.E_GOING_DOWN, msg) ->Arakoon_exc.E_GOING_DOWN, msg, true, true
@@ -88,14 +95,14 @@ let handle_exception oc exn=
   | Server.FOOBAR -> Arakoon_exc.E_UNKNOWN_FAILURE, "unkown failure", true, true
   | _ -> Arakoon_exc.E_UNKNOWN_FAILURE, "unknown failure", false, true
   in
-  Lwt_log.error_f "Exception during client request (%s) => rc:%lx msg:%s" 
+  Lwt_log.error_f "[connection:%i] Exception during client request (%s) => rc:%lx msg:%s"cid 
     (Printexc.to_string exn)  (Arakoon_exc.int32_of_rc rc) msg
   >>= fun () ->
   
   Arakoon_exc.output_exception oc rc msg >>= fun () ->
   begin
 	  if close_socket
-	  then Lwt_log.debug "Closing client socket" >>= fun () -> Lwt_io.close oc
+	  then Lwt_log.debug_f ~section "[connection:%i] Closing client socket" cid >>= fun () -> Lwt_io.close oc
 	  else Lwt.return ()
   end >>= fun () ->
   if is_fatal
@@ -103,39 +110,40 @@ let handle_exception oc exn=
   else Lwt.return close_socket
 
 
-let decode_sequence ic =
+let decode_sequence cid ic =
   begin
     Llio.input_string ic >>= fun data ->
-    Lwt_log.debug_f "Read out %d bytes" (String.length data) >>= fun () ->
+    Lwt_log.debug_f ~section "[connection:%i] Read out %d bytes" cid (String.length data) >>= fun () ->
     let update,_ = Update.from_buffer data 0 in
     match update with
       | Update.Sequence updates ->
         Lwt.return updates
       | _ ->  raise (XException (Arakoon_exc.E_UNKNOWN_FAILURE,
-             "should have been a sequence"))
+             "[connection]:"^(string_of_int cid)^" should have been a sequence"))
   end
 
-let handle_sequence ~sync ic oc backend =
+let handle_sequence cid ~sync ic oc backend =
   begin
     Lwt.catch
       (fun () ->
         begin
-          decode_sequence ic >>= fun updates ->
+          decode_sequence cid ic >>= fun updates ->
           backend # sequence ~sync updates >>= fun () ->
-          response_ok_unit oc
+          response_ok_unit cid oc
         end )
-      ( handle_exception oc )
+      (handle_exception cid oc)
 
   end
 
-let one_command (ic,oc) (backend:Backend.backend) =
+let one_command (ic,oc,cid) (backend:Backend.backend) =
   read_command (ic,oc) >>= function
     | PING ->
       begin
         Llio.input_string ic >>= fun client_id ->
 	    Llio.input_string ic >>= fun cluster_id ->
         backend # hello client_id cluster_id >>= fun (rc,msg) ->
-        response_rc_string oc rc msg
+        Lwt_log.info_f "[connection:%i] PING, client:%s, cluster:%s" cid client_id cluster_id >>= fun () ->
+        response_rc_string cid oc rc msg
       end
     | EXISTS ->
       begin
@@ -143,8 +151,9 @@ let one_command (ic,oc) (backend:Backend.backend) =
 	Llio.input_string ic >>= fun key ->
 	Lwt.catch
 	  (fun () -> backend # exists ~allow_dirty key >>= fun exists ->
-	    response_rc_bool oc 0l exists)
-	  (handle_exception oc)
+        Lwt_log.debug_f ~section "[connection:%i] Exists, key: %s" cid key >>= fun () ->
+	    response_rc_bool cid oc 0l exists)
+	  (handle_exception cid oc)
       end
     | GET ->
       begin
@@ -152,8 +161,9 @@ let one_command (ic,oc) (backend:Backend.backend) =
         Llio.input_string ic >>= fun  key ->
 	    Lwt.catch
 	      (fun () -> backend # get ~allow_dirty key >>= fun value ->
-	        response_rc_string oc 0l value)
-	      (handle_exception oc)
+            Lwt_log.debug_f ~section "[connection:%i] Get, key: %s" cid key >>= fun () ->
+	        response_rc_string cid oc 0l value)
+	      (handle_exception cid oc)
       end
     | ASSERT ->
       begin
@@ -162,9 +172,10 @@ let one_command (ic,oc) (backend:Backend.backend) =
 	Llio.input_string_option ic >>= fun vo ->
 	Lwt.catch
 	  (fun () -> backend # aSSert ~allow_dirty key vo >>= fun () ->
-	    response_ok_unit oc
+        Lwt_log.debug_f ~section "[connection:%i] Assert, Key:%s" cid key >>= fun () ->
+	    response_ok_unit cid oc
 	  )
-	  (handle_exception oc)
+	  (handle_exception cid oc)
       end
     | ASSERTEXISTS ->
       begin
@@ -172,9 +183,10 @@ let one_command (ic,oc) (backend:Backend.backend) =
 	Llio.input_string ic        >>= fun key ->
 	Lwt.catch
 	  (fun () -> backend # aSSert_exists ~allow_dirty key>>= fun () ->
-	    response_ok_unit oc
+        Lwt_log.debug_f ~section "[connection:%i] Assert_exists, Key:%s" cid key >>= fun () ->
+	    response_ok_unit cid oc
 	  )
-	  (handle_exception oc)
+	  (handle_exception cid oc)
       end
     | SET ->
 	begin
@@ -182,9 +194,10 @@ let one_command (ic,oc) (backend:Backend.backend) =
       Llio.input_string ic >>= fun value ->
 	  Lwt.catch
 	    (fun () -> backend # set key value >>= fun () ->
-	      response_ok_unit oc
+          Lwt_log.debug_f ~section "[connection:%i] SET, key:%s, Value:%s" cid key value >>= fun () ->
+	      response_ok_unit cid oc
 	    )
-	    (handle_exception oc)
+	    (handle_exception cid oc)
 	end
     | DELETE ->
 	begin
@@ -192,8 +205,9 @@ let one_command (ic,oc) (backend:Backend.backend) =
       Lwt.catch
 	    (fun () ->
 	      backend # delete key >>= fun () ->
-	      response_ok_unit oc)
-	    (handle_exception oc)
+          Lwt_log.debug_f ~section "[connection:%i] Delete, key:%s" cid key >>= fun () ->
+	      response_ok_unit cid oc)
+	    (handle_exception cid oc)
 	end
     | RANGE ->
       begin
@@ -206,11 +220,12 @@ let one_command (ic,oc) (backend:Backend.backend) =
         Lwt.catch
 	      (fun () ->
 	        backend # range ~allow_dirty first finc last linc max >>= fun list ->
+            Lwt_log.debug_f ~section "[connection: %i] range %s %b %s %b %i" cid (_s_ first) finc (_s_ last) linc max >>= fun () ->
 	        Llio.output_int32 oc 0l >>= fun () ->
 	        Llio.output_list Llio.output_string oc list >>= fun () ->
             Lwt.return false
 	      )
-	      (handle_exception oc )
+	      (handle_exception cid oc )
 	end
     | RANGE_ENTRIES ->
       begin
@@ -224,13 +239,14 @@ let one_command (ic,oc) (backend:Backend.backend) =
 	      (fun () ->
 	        backend # range_entries ~allow_dirty first finc last linc max
 	        >>= fun (list:(string*string) list) ->
+            Lwt_log.debug_f ~section "[connection: %i] range_entries %s %b %s %b %i" cid (_s_ first) finc (_s_ last) linc max >>= fun () ->
 	        Llio.output_int32 oc 0l >>= fun () ->
 	        let size = List.length list in
-	        Lwt_log.debug_f "size = %i" size >>= fun () ->
+	        Lwt_log.debug_f ~section "size = %i" size >>= fun () ->
 	        Llio.output_list Llio.output_string_pair oc list >>= fun () ->
             Lwt.return false
 	      )
-	      (handle_exception oc)
+	      (handle_exception cid oc)
       end
     | REV_RANGE_ENTRIES ->
       begin
@@ -244,24 +260,27 @@ let one_command (ic,oc) (backend:Backend.backend) =
 	      (fun () ->
 	        backend # rev_range_entries ~allow_dirty first finc last linc max
 	        >>= fun (list:(string*string) list) ->
+            Lwt_log.debug_f ~section "[connection: %i] rev_range_entries %s %b %s %b %i" cid (_s_ first) finc (_s_ last) linc max >>= fun () ->
 	        Llio.output_int32 oc 0l >>= fun () ->
 	        let size = List.length list in
-	        Lwt_log.debug_f "size = %i" size >>= fun () ->
+	        Lwt_log.debug_f ~section "[connection: %i] size = %i" cid size >>= fun () ->
 	        Llio.output_list Llio.output_string_pair oc list >>= fun () ->
             Lwt.return false
 	      )
-	      (handle_exception oc)
+	      (handle_exception cid oc)
       end
     | LAST_ENTRIES ->
       begin
 	    Sn.input_sn ic >>= fun i ->
 	    Llio.output_int32 oc 0l >>= fun () ->
 	    backend # last_entries i oc >>= fun () ->
+        Lwt_log.debug_f ~section "[connection:%i] LAST_EXTRIES, i:%s" cid (Sn.string_of i) >>= fun () ->
         Lwt.return false
       end
     | WHO_MASTER ->
       begin
 	    backend # who_master () >>= fun m ->
+        Lwt_log.debug_f ~section "[connection:%i] WHO_MASTER, returns:%s" cid (_s_ m) >>= fun () ->
 	    Llio.output_int32 oc 0l >>= fun () ->
 	    Llio.output_string_option oc m >>= fun () ->
 	    Lwt.return false
@@ -269,6 +288,7 @@ let one_command (ic,oc) (backend:Backend.backend) =
     | EXPECT_PROGRESS_POSSIBLE ->
       begin
 	    backend # expect_progress_possible () >>= fun poss ->
+        Lwt_log.debug_f ~section "[connection:%i] EXPECT_PROGRESS_POSSIBLE" cid >>= fun () ->
 	    Llio.output_int32 oc 0l >>= fun () ->
 	    Llio.output_bool oc poss >>= fun () ->
 	    Lwt.return false
@@ -279,6 +299,7 @@ let one_command (ic,oc) (backend:Backend.backend) =
 	    Llio.input_string_option ic >>= fun expected ->
         Llio.input_string_option ic >>= fun wanted ->
 	    backend # test_and_set key expected wanted >>= fun vo ->
+        Lwt_log.debug_f ~section "[connection:%i] TEST_AND_SET, key:%s, expected:%s ,wanted:%s" cid key (_s_ expected) (_s_ wanted) >>= fun () ->
 	    Llio.output_int oc 0 >>= fun () ->
         Llio.output_string_option oc vo >>= fun () ->
         Lwt.return false
@@ -291,12 +312,13 @@ let one_command (ic,oc) (backend:Backend.backend) =
 	      (fun () ->
 	        begin
 	          backend # user_function name po >>= fun ro ->
+              Lwt_log.debug_f ~section "[connection:%i] user_function, name:%s , po:%s" cid name (_s_ po) >>= fun () ->
 	          Llio.output_int oc 0 >>= fun () ->
 	          Llio.output_string_option oc ro >>= fun () ->
               Lwt.return false
 	        end
 	      )
-	      (handle_exception oc)
+	      (handle_exception cid oc)
       end
     | PREFIX_KEYS ->
       begin
@@ -304,9 +326,10 @@ let one_command (ic,oc) (backend:Backend.backend) =
 	    Llio.input_string ic >>= fun key ->
 	    Llio.input_int    ic >>= fun max ->
 	    backend # prefix_keys ~allow_dirty key max >>= fun keys ->
+        Lwt_log.debug_f ~section "[connection:%i] PREFIX_KEYS, key:%s, max:%i" cid key max>>= fun () ->
         let size = List.length keys in
 	    Llio.output_int oc 0 >>= fun () ->
-        Lwt_log.debug_f "size = %i" size >>= fun () ->
+        Lwt_log.debug_f ~section "size = %i" size >>= fun () ->
 	    Llio.output_int oc size >>= fun () ->
 	    Lwt_list.iter_s (Llio.output_string oc) keys >>= fun () ->
 	    Lwt.return false
@@ -328,30 +351,33 @@ let one_command (ic,oc) (backend:Backend.backend) =
 	    Lwt.catch
 	      (fun () ->
 	        backend # multi_get ~allow_dirty keys >>= fun values ->
+            Lwt_log.debug_f ~section "[connection:%i] MULTI-GET" cid >>= fun () ->
 	        Llio.output_int oc 0 >>= fun () ->
 	        Llio.output_int oc length >>= fun () ->
 	        Lwt_list.iter_s (Llio.output_string oc) values >>= fun () ->
 	        Lwt.return false
 	      )
-	      (handle_exception oc)
+	      (handle_exception cid oc)
       end
-    | SEQUENCE -> handle_sequence ~sync:false ic oc backend
-    | SYNCED_SEQUENCE -> handle_sequence ~sync:true ic oc backend
+    | SEQUENCE -> handle_sequence cid ~sync:false ic oc backend
+    | SYNCED_SEQUENCE -> handle_sequence cid ~sync:true ic oc backend
     | MIGRATE_RANGE ->
       begin
         Lwt.catch(
           fun () ->
             Interval.input_interval ic >>= fun interval ->
-            decode_sequence ic >>= fun updates ->
+            decode_sequence cid ic >>= fun updates ->
             let interval_update = Update.SetInterval interval in
             let updates' =  interval_update :: updates in
             backend # sequence ~sync:false updates' >>= fun () ->
-            response_ok_unit oc
-        ) (handle_exception oc)
+            Lwt_log.debug_f ~section "[connection:%i] MIGRATE_RANGE" cid >>= fun () ->
+            response_ok_unit cid oc
+        ) (handle_exception cid oc)
       end
     | STATISTICS ->
       begin
 	    let s = backend # get_statistics () in
+        Lwt_log.debug_f ~section "[connection:%i] STATISTICS" cid>>= fun () ->
 	    let b = Buffer.create 100 in
 	    Statistics.to_buffer b s;
 	    let bs = Buffer.contents b in
@@ -364,7 +390,7 @@ let one_command (ic,oc) (backend:Backend.backend) =
 	    let sw () = Int64.bits_of_float (Unix.gettimeofday()) in
 	    let t0 = sw() in
 	    let cb' n =
-	      Lwt_log.debug_f "CB' %i" n >>= fun () ->
+	      Lwt_log.debug_f ~section "CB' %i" n >>= fun () ->
 	      Llio.output_int oc 0 >>= fun () -> (* ok *)
 	      Llio.output_int oc n >>= fun () ->
           Lwt_io.flush oc
@@ -372,7 +398,7 @@ let one_command (ic,oc) (backend:Backend.backend) =
 	    let cb  =
           let count = ref 0 in
           fun () ->
-	        Lwt_log.debug_f "CB %i" !count >>= fun () ->
+	        Lwt_log.debug_f ~section "CB %i" !count >>= fun () ->
             let () = incr count in
 	        let ts = sw() in
 	        let d = Int64.sub ts t0 in
@@ -383,12 +409,12 @@ let one_command (ic,oc) (backend:Backend.backend) =
 	    Llio.input_int ic >>= fun n ->
 	    Lwt.catch
 	      (fun () ->
-	        Lwt_log.info_f "... Start collapsing ... (n=%i)" n >>= fun () ->
+	        Lwt_log.info_f "[connection: %i]... Start collapsing ... (n=%i)" cid n >>= fun () ->
 	        backend # collapse n cb' cb >>= fun () ->
-	        Lwt_log.info "... Finished collapsing ..." >>= fun () ->
+            Lwt_log.info_f "[connection:%i] ... Finished collapsing ..." cid >>= fun () ->
 	        Lwt.return false 
 	      )
-	      (handle_exception oc)
+	      (handle_exception cid oc)
       end
     | SET_INTERVAL ->
       begin
@@ -396,9 +422,10 @@ let one_command (ic,oc) (backend:Backend.backend) =
 	      (fun () ->
             Interval.input_interval ic >>= fun interval ->
             backend # set_interval interval >>= fun () ->
-            response_ok_unit oc
+            Lwt_log.debug_f ~section "[connection:%i] SET-INTERVAL" cid >>= fun () ->
+            response_ok_unit cid oc
           )
-          (handle_exception oc)
+          (handle_exception cid oc)
           
 	  end
     | GET_INTERVAL ->
@@ -406,28 +433,31 @@ let one_command (ic,oc) (backend:Backend.backend) =
         Lwt.catch(
           fun() ->
             backend # get_interval () >>= fun interval ->
+            Lwt_log.debug_f ~section "[connection:%i] GET-INTERVAL" cid >>= fun () ->
             Llio.output_int oc 0 >>= fun () ->
             Interval.output_interval oc interval >>= fun () ->
             Lwt.return false
         )
-          (handle_exception oc)
+          (handle_exception cid oc)
       end
     | GET_ROUTING ->
       Lwt.catch
 	    (fun () -> backend # get_routing () >>= fun routing ->
+          Lwt_log.debug_f ~section "[connection:%i] GET-ROUTING" cid >>= fun () ->
 	      Llio.output_int oc 0 >>= fun () ->
 	      Routing.output_routing oc routing >>= fun () ->
 	      Lwt.return false
 	    )
-	    (handle_exception oc)
+	    (handle_exception cid oc)
     | SET_ROUTING ->
       begin
 	    Routing.input_routing ic >>= fun routing ->
 	    Lwt.catch
 	      (fun () ->
 	        backend # set_routing routing >>= fun () ->
-	        response_ok_unit oc)
-	      (handle_exception oc)
+            Lwt_log.debug_f ~section "[connection:%i] SET-ROUTING" cid >>= fun () ->
+	        response_ok_unit cid oc)
+	      (handle_exception cid oc)
       end
     | SET_ROUTING_DELTA ->
       begin
@@ -437,42 +467,46 @@ let one_command (ic,oc) (backend:Backend.backend) =
             Llio.input_string ic >>= fun sep ->
             Llio.input_string ic >>= fun right ->
             backend # set_routing_delta left sep right >>= fun () ->
-            response_ok_unit oc )
-          (handle_exception oc)
+            Lwt_log.debug_f ~section "[connection:%i] SET-ROUTING-DELTA, left:%s, set:%s, right:%s" cid left sep right >>= fun () ->
+            response_ok_unit cid oc )
+          (handle_exception cid oc)
       end
     | GET_KEY_COUNT ->
       begin
         Lwt.catch
           (fun() ->
             backend # get_key_count () >>= fun kc ->
-            response_ok_int64 oc kc)
-          (handle_exception oc)
+            Lwt_log.debug_f ~section "[connection:%i] GET-KEY-COUNT" cid >>= fun () ->
+            response_ok_int64 cid oc kc)
+          (handle_exception cid oc)
       end
     | GET_DB ->
       begin
         Lwt.catch
           (fun() ->
             backend # get_db (Some oc) >>= fun () ->
+            Lwt_log.debug_f ~section "[connection:%i] GET-DB" cid >>= fun () ->
             Lwt.return false
           )
-          (handle_exception oc)
+          (handle_exception cid oc)
       end
     | OPT_DB ->
       begin
         Lwt.catch
           ( fun () ->
             backend # optimize_db () >>= fun () ->
-            response_ok_unit oc 
+            Lwt_log.debug_f ~section "[connection:%i] OPT-DB" cid >>= fun () ->
+            response_ok_unit cid oc 
           )
-          (handle_exception oc)
+          (handle_exception cid oc)
       end
     | DEFRAG_DB ->
       begin
-        Lwt_log.info "DEFRAG_DB" >>= fun () ->
         Lwt.catch
           (fun () -> backend # defrag_db () >>= fun () ->
-            response_ok_unit oc)
-          (handle_exception oc)
+            Lwt_log.debug_f ~section "[connection:%i] DEFRAG-DB" cid >>= fun () ->
+            response_ok_unit cid oc)
+          (handle_exception cid oc)
       end
     | CONFIRM ->
 	  begin
@@ -480,9 +514,10 @@ let one_command (ic,oc) (backend:Backend.backend) =
         Llio.input_string ic >>= fun value ->
 	    Lwt.catch
 	      (fun () -> backend # confirm key value >>= fun () ->
-	        response_ok_unit oc
+            Lwt_log.debug_f ~section "[connection:%i] CONFIRM, key:%s, value:%s" cid key value >>= fun () ->
+	        response_ok_unit cid oc
 	      )
-	      (handle_exception oc)
+	      (handle_exception cid oc)
 	  end
         
     | GET_NURSERY_CFG ->
@@ -491,13 +526,14 @@ let one_command (ic,oc) (backend:Backend.backend) =
           fun () ->
             backend # get_routing () >>= fun routing ->
             backend # get_cluster_cfgs () >>= fun cfgs ->
+            Lwt_log.debug_f ~section "[connection:%i] GET_NURSERY_CFG" cid >>= fun () ->
             let buf = Buffer.create 32 in
             NCFG.ncfg_to buf (routing,cfgs);
             Llio.output_int oc 0 >>= fun () ->
             Llio.output_string oc (Buffer.contents buf) >>= fun () ->
             Lwt.return false
         )
-          ( handle_exception oc )
+          ( handle_exception cid oc )
       end
     | SET_NURSERY_CFG ->
       begin
@@ -506,9 +542,10 @@ let one_command (ic,oc) (backend:Backend.backend) =
             Llio.input_string ic >>= fun cluster_id ->
             ClientCfg.input_cfg ic >>= fun cfg ->
             backend # set_cluster_cfg cluster_id cfg >>= fun () ->
-            response_ok_unit oc
+            Lwt_log.debug_f ~section "[connection:%i] SET_NURSERY_CFG" cid >>= fun () ->
+            response_ok_unit cid oc
         )
-          ( handle_exception oc )
+          ( handle_exception cid oc )
       end
     | GET_FRINGE ->
       begin
@@ -524,26 +561,26 @@ let one_command (ic,oc) (backend:Backend.backend) =
                 Routing.LOWER_BOUND
             in
 	        backend # get_fringe boundary direction >>= fun kvs ->
-            Lwt_log.debug "get_fringe backend op complete" >>= fun () ->
+            Lwt_log.debug_f ~section "[connection:%i] GET_FRINGE backend op complete" cid >>= fun () ->
             Llio.output_int oc 0 >>= fun () ->
 	        Llio.output_kv_list oc kvs >>= fun () ->
-            Lwt_log.debug "get_fringe all done" >>= fun () ->
+            Lwt_log.debug_f ~section "[connection:%i] GET_FRINGE all done" cid >>= fun () ->
 	        Lwt.return false
 	      )
-	      (handle_exception oc)
+	      (handle_exception cid oc)
       end
     | DELETE_PREFIX ->
       begin
         Lwt.catch 
           ( fun () ->
             Llio.input_string ic >>= fun prefix ->
-            Lwt_log.debug_f "delete_prefix %S" prefix >>= fun () ->
             backend # delete_prefix prefix >>= fun n_deleted ->
+            Lwt_log.debug_f ~section "[connection:%i] DELETE-PREFIX" cid >>= fun () ->
             Llio.output_int oc 0 >>= fun () ->
             Llio.output_int oc n_deleted >>= fun () ->
             Lwt.return false
           ) 
-          (handle_exception oc)
+          (handle_exception cid oc)
       end
     | VERSION ->
       Llio.output_int oc 0 >>= fun () ->
@@ -559,7 +596,7 @@ let one_command (ic,oc) (backend:Backend.backend) =
       Lwt.return false
         
 let protocol backend connection =
-  let ic,oc = connection in
+  let ic,oc,cid = connection in
   let check magic version =
     if magic = _MAGIC && version = _VERSION then Lwt.return ()
     else Llio.lwt_failfmt "MAGIC %lx or VERSION %x mismatch" magic version
@@ -582,7 +619,7 @@ let protocol backend connection =
 	  one_command connection backend >>= fun closed ->
 	  Lwt_io.flush oc >>= fun() ->
 	  if closed
-	  then Lwt_log.debug "leaving client loop" 
+	  then Lwt_log.debug_f ~section "[connection:%i] leaving client loop" cid
 	  else loop ()
     end
   in

--- a/src/node/local_store.ml
+++ b/src/node/local_store.ml
@@ -331,8 +331,17 @@ let _set_master bdb master (lease_start:int64) =
 let _with_tx (db: Camltc.Hotc.t) (f:B.bdb -> 'a Lwt.t) =
   Camltc.Hotc.transaction db
 	(fun db ->
+      let t0 = Unix.gettimeofday() in
 	  f db >>= fun (a:'a) ->
-	  Lwt.return a)
+      let t = ( Unix.gettimeofday() -. t0) in
+      if t > 1.0 
+      then begin
+        Lwt_log.info_f "Tokyo cabinet transaction took %fs" t >>= fun () ->
+        Lwt.return a
+      end
+      else
+	    Lwt.return a
+    )
 
 (* let _tx_with_incr _ _ _ = failwith "_tx_with_incr" *)
 

--- a/src/node/mem_store.ml
+++ b/src/node/mem_store.ml
@@ -280,11 +280,13 @@ object (self: #store)
 end
 
 let make_mem_store ?(read_only=false) db_name =
+  Lwt_log.debug_f "mem_store:: make store with datbase:%s" db_name >>= fun () ->
   let store = new mem_store db_name in
   let store2 = (store :> store) in
   Lwt.return store2
 
 let copy_store old_location new_location overwrite =
+  Lwt_log.debug_f "mem_store:: copy store%s to %s" old_location new_location >>= fun () ->
   Lwt.return ()
 
 

--- a/src/tools/server.ml
+++ b/src/tools/server.ml
@@ -32,28 +32,28 @@ let no_callback = Lwt.return
 exception FOOBAR
 
 
-let deny (ic,oc) = 
+let deny (ic,oc,cid) = 
   Lwt_log.warning "max connections reached, denying this one" >>= fun () ->
   Llio.output_int oc 0xfe >>= fun () ->
   Llio.output_string oc "too many clients"
    
 
-let session_thread (sid:string) protocol fd = 
+let session_thread (sid:string) protocol fd cid host port = 
   Lwt.catch
     (fun () ->
       let ic = Lwt_io.of_fd ~mode:Lwt_io.input fd
       and oc = Lwt_io.of_fd ~mode:Lwt_io.output fd
-      in protocol (ic,oc) 
+      in protocol  (ic,oc,cid)
     )
     (function
       | FOOBAR as foobar-> 
-          Lwt_log.fatal "propagating FOOBAR" >>= fun () ->
+          Lwt_log.fatal_f "[connection:%i] propagating FOOBAR" cid >>= fun () ->
           Lwt.fail foobar
-      | exn -> info_f ~exn "exiting session (%s)" sid)
+      | exn -> info_f ~exn "[connection:%i] exiting session(%s), host:%s, port:%i" cid sid host port)
   >>= fun () -> 
   Lwt.catch 
     ( fun () -> Lwt_unix.close fd )
-    ( fun exn -> Lwt_log.debug "Exception on closing of socket" )
+    ( fun exn -> Lwt_log.debug_f "[connection:%i] Exception on closing of socket" cid )
 
 let create_connection_allocation_scheme max = 
   let counter = ref 0 in
@@ -73,6 +73,8 @@ let make_server_thread
     ?(teardown_callback = no_callback)
     ~scheme
     host port protocol =
+  let () = Lwt_log.append_rule "paxos" Lwt_log.Debug in (* TODO_347: Is this best place?*)
+  let () = Lwt_log.append_rule "tcp_messaging" Lwt_log.Debug in (* TODO_347: Is this best place?*)
   let new_socket () = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   let socket_address = Network.make_address host port in
   begin
@@ -81,48 +83,55 @@ let make_server_thread
     Lwt_unix.bind listening_socket socket_address;
     Lwt_unix.listen listening_socket 1024;
     let maybe_take,release = scheme in
+    let n_connection = ref 0 in
+    let max_connections = 1000000 in
+    let log_key = Lwt.new_key () in
     let rec server_loop () =
       Lwt.catch
-	(fun () ->
-	  Lwt_unix.accept listening_socket >>= fun (fd, _) ->
-          begin
-            match maybe_take () with
-              | None    -> Lwt.ignore_result (session_thread "--" deny fd)
-              | Some id ->
-	        Lwt.ignore_result 
-		  (
-                    Lwt_log.info_f "%s:session (%i)" name id >>= fun () ->
-                    let sid = string_of_int id in
-                    session_thread sid protocol fd >>= fun () ->
-                    release();
-                    Lwt.return()
-		  )
-          end;
+	    (fun () ->
+	      Lwt_unix.accept listening_socket >>= fun (fd, _) ->
+          if !n_connection >= max_connections 
+          then n_connection:=1
+          else
+            begin
+              match maybe_take () with
+                | None    -> Lwt.ignore_result (session_thread "--" deny fd 0 host port)
+                | Some id ->
+                    incr n_connection;
+	                Lwt.ignore_result 
+		              (
+                        Lwt_log.info_f "[connection:%i] %s:session (%i), host:%s, port:%i" !n_connection name id host port >>= fun () ->
+                        let sid = string_of_int id in
+                        session_thread sid protocol fd !n_connection host port >>= fun () ->
+                        release();
+                        Lwt.return()
+		              )   
+            end;
           Lwt.return ()
-	)
-	(function 
-	  | Unix.Unix_error (Unix.EMFILE,s0,s1) -> 
-	    let timeout = 4.0 in
-	    (* if we don't sleep, this will go into a spinning loop of
-	       failfasts; 
-	       we want to block until an fd is available,
-	       but alas, I found no such API.
-	    *)
-	    Lwt_log.warning_f 
-	      "OUT OF FDS during accept (%s,%s) on port %i => sleeping %.1fs" 
-	      s0 s1 port timeout
-	    >>= fun () ->
-	    Lwt_unix.sleep timeout
-	  | e -> Lwt.fail e
-	)
+	    )
+	    (function 
+	      | Unix.Unix_error (Unix.EMFILE,s0,s1) -> 
+	          let timeout = 4.0 in
+	          (* if we don't sleep, this will go into a spinning loop of
+	             failfasts; 
+	             we want to block until an fd is available,
+	             but alas, I found no such API.
+	          *)
+	          Lwt_log.warning_f 
+	            "[connection:%i] OUT OF FDS during accept (%s,%s) on port %i => sleeping %.1fs" !n_connection
+	            s0 s1 port timeout
+	          >>= fun () ->
+	          Lwt_unix.sleep timeout
+	      | e -> Lwt.fail e
+	    )
       >>= fun () ->
-      server_loop ()
+      Lwt.with_value log_key (Some n_connection) ( fun () -> server_loop () )
     in
     let r  = fun () ->
       Lwt.catch
-	(fun ()  -> setup_callback () >>= fun () -> server_loop ())
-	(fun exn -> info_f ~exn "shutting down server on port %i" port)
-      >>= fun () ->
+	    (fun ()  -> setup_callback () >>= fun () -> server_loop ())
+	    (fun exn -> info_f ~exn "[connection:%i] shutting down server on port %i" !n_connection port)
+             >>= fun () ->
       Lwt_unix.close listening_socket >>= fun () ->
       teardown_callback()
     in r

--- a/src/tools/server_test.ml
+++ b/src/tools/server_test.ml
@@ -24,7 +24,7 @@ open OUnit
 open Lwt
 open Lwt_log
 
-let echo_protocol (ic,oc) = 
+let echo_protocol (ic,oc,cid) = 
   let size = 1024 in
   let buffer = String.create size in
   let rec loop () = 


### PR DESCRIPTION
# This branch till now ignores:
- The connecting dss command line utility also reports its version/revision information so that compatibility problems can be confirmed if necessary.
- DSS uses different unique ids for “manager” threads within the daemon process, so that the log lines they emit can also be correlated.
- Log fd, peer address
# Some logging sections were added
- paxos
- client_protocol
- tcp_messaging

The default behavior for the logger will be determied in server.ml#76, its set to debug as default.
It's user choice to set env_variable LWT_DEBUG as stated in README. 
# These features were added to the current branch"
- Associate a unique connection id with each connection
- Use connection id as log prefix when working with it (see Lwt.new_key, Lwt.with_value
  and Lwt.get to propagate the id through the lwt code using threadlocal
  storage)
- Log fd, peer address and port and local address and port at connect, accept and at shutdown / disconnect, with the connection id as prefix
- expose the Arakoon decision process on consensus and election. Paxos
- Measure every write to disk and log the time it took if this writeoperation
  takes more than 1 second
- When rebuilding a tc file from the tlf files, it's usefull to log what tlf file is being replayed
# The "milli-second(-like) " option is implemented in 1.5.0 where the current branch is based on.
