### PR TITLE
Jenkins: Use LXC containers

### DIFF
--- a/buildInSandbox.sh
+++ b/buildInSandbox.sh
@@ -1,19 +1,19 @@
-#!/bin/bash
+#!/bin/bash -xue
 set -e
 
 
 ocamlbuild $@ -use-ocamlfind arakoon.native
 
-sudo mkdir -p /opt/qbase3/apps/arakoon/bin/
-sudo cp arakoon.native /opt/qbase3/apps/arakoon/bin/arakoon
-sudo mkdir -p /opt/qbase3/lib/pymonkey/extensions/arakoon/server/
-sudo mkdir -p /opt/qbase3/lib/pymonkey/extensions/arakoon/client/
-sudo cp -r extension/server/* /opt/qbase3/lib/pymonkey/extensions/arakoon/server/
-sudo cp -r extension/client/* /opt/qbase3/lib/pymonkey/extensions/arakoon/client/
+mkdir -p /opt/qbase3/apps/arakoon/bin/
+cp arakoon.native /opt/qbase3/apps/arakoon/bin/arakoon
+mkdir -p /opt/qbase3/lib/pymonkey/extensions/arakoon/server/
+mkdir -p /opt/qbase3/lib/pymonkey/extensions/arakoon/client/
+cp -r extension/server/* /opt/qbase3/lib/pymonkey/extensions/arakoon/server/
+cp -r extension/client/* /opt/qbase3/lib/pymonkey/extensions/arakoon/client/
 
-sudo mkdir -p /opt/qbase3/var/tests/arakoon_system_tests/
-sudo touch /opt/qbase3/var/tests/arakoon_system_tests/__init__.py
-sudo cp -r extension/test/* /opt/qbase3/var/tests/arakoon_system_tests/
-sudo mkdir -p /opt/qbase3/lib/python/site-packages/arakoon/
-sudo cp src/client/python/*.py /opt/qbase3/lib/python/site-packages/arakoon/
+mkdir -p /opt/qbase3/var/tests/arakoon_system_tests/
+touch /opt/qbase3/var/tests/arakoon_system_tests/__init__.py
+cp -r extension/test/* /opt/qbase3/var/tests/arakoon_system_tests/
+mkdir -p /opt/qbase3/lib/python/site-packages/arakoon/
+cp src/client/python/*.py /opt/qbase3/lib/python/site-packages/arakoon/
 

--- a/extension/test/server/right/system_tests_anomaly.py
+++ b/extension/test/server/right/system_tests_anomaly.py
@@ -145,7 +145,7 @@ def build_iptables_block_rules( tcp_port ) :
 
 def get_current_iptables_rules (): 
     rules_file = q.system.fs.joinPaths( q.dirs.tmpDir, "iptables-rules-save")
-    cmd = "iptables-save > %s" % rules_file
+    cmd = "sudo /sbin/iptables-save > %s" % rules_file
     Common.run_cmd( cmd )
     rules_file_contents = q.system.fs.fileGetContents( rules_file )
     return rules_file_contents.split( "\n") [5:-3]
@@ -158,7 +158,7 @@ def apply_iptables_rules ( rules ) :
         lines = rule.split("\n")
         for line in lines :
             if line.strip() != "" :
-                cmd = "iptables %s" % line
+                cmd = "sudo /sbin/iptables %s" % line
                 logging.info("cmd=%s", cmd)
                 Common.run_cmd( cmd, False )
         
@@ -326,7 +326,7 @@ def iterate_block_unblock_master ( ):
     iterate_block_unblock_nodes ( 60, [ master_id ] )
 
 def flush_all_rules() :
-    cmd = "iptables -F"
+    cmd = "sudo /sbin/iptables -F"
     Common.run_cmd( cmd, False )
     
 def iptables_teardown( removeDirs ) :

--- a/extension/test/server/system_tests_common.py
+++ b/extension/test/server/system_tests_common.py
@@ -565,7 +565,7 @@ def setup_n_nodes_base(c_id, node_names, force_master,
                        base_dir, base_msg_port, base_client_port, 
                        extra = None):
     
-    q.system.process.run( "/sbin/iptables -F" )
+    q.system.process.run( "sudo /sbin/iptables -F" )
     
     cluster = q.manage.arakoon.getCluster( c_id )
     cluster.tearDown()

--- a/jenkins/archive_version.sh
+++ b/jenkins/archive_version.sh
@@ -1,1 +1,3 @@
+#!/bin/bash -xue
+
 ./arakoon.native --version > arakoonqpackage.version.txt

--- a/jenkins/base/005_install_ubuntu_dependencies.sh
+++ b/jenkins/base/005_install_ubuntu_dependencies.sh
@@ -2,6 +2,6 @@
 
 sudo aptitude update || true
 
-for PKG in texlive texlive-latex-extra darcs git automake fakeroot python-epydoc python-setuptools debhelper dh-ocaml python-virtualenv graphviz ruby1.9.1 rubygems1.9.1 ruby1.9.1-dev libxml2-dev libxslt-dev; do
+for PKG in texlive texlive-latex-extra git python-epydoc graphviz; do
     sudo aptitude install -yVDq $PKG
 done

--- a/jenkins/base/008_install_dev_env.sh
+++ b/jenkins/base/008_install_dev_env.sh
@@ -1,1 +1,10 @@
-python tools/setup_env.py 
+#!/bin/bash -xue
+
+which opam > /dev/null || { echo 'opam not found!'; exit 1; }
+{ opam remote list | grep Incubaid/opam-repository-devel > /dev/null; } || { opam remote add incubaid-devel -k git git://github.com/Incubaid/opam-repository-devel.git; }
+
+opam switch 4.00.1
+eval `opam config env`
+
+opam install conf-libev
+opam install lwt camlbz2 camltc bisect

--- a/jenkins/base/010_build.sh
+++ b/jenkins/base/010_build.sh
@@ -1,11 +1,6 @@
+#!/bin/bash -xue
 
-
-echo WORKSPACE=${WORKSPACE}
-BUILD_ENV=${WORKSPACE%${JOB_NAME}}
-echo BUILD_ENV=${BUILD_ENV}
-PATH=${BUILD_ENV}/ROOT/OCAML/bin:$PATH
-eval `${BUILD_ENV}/ROOT/OPAM/bin/opam config env -r ${BUILD_ENV}/ROOT/OPAM_ROOT`
-
+eval `opam config env`
 
 ocamlfind printconf
 ocamlfind list | grep bz2
@@ -14,6 +9,10 @@ ocamlfind list | grep camltc
 
 ocamlbuild -clean
 ocamlbuild -use-ocamlfind arakoon.native arakoon.byte
+
+echo "Fixup symlinks (absolute to relative)"
+symlinks -c .
+
 #make coverage 
 #./arakoon.d.byte --run-all-tests-xml foobar.xml
 ./arakoon.native --run-all-tests-xml foobar.xml

--- a/jenkins/base/seed
+++ b/jenkins/base/seed
@@ -1,0 +1,1 @@
+arakoon-1.x-ubuntu-12.10-quantal-20130301

--- a/jenkins/build_in_shandbox.sh
+++ b/jenkins/build_in_shandbox.sh
@@ -1,8 +1,7 @@
+#!/bin/bash -xue
+
 echo WORKSPACE=${WORKSPACE}
-BUILD_ENV=${WORKSPACE%${JOB_NAME}}
-echo BUILD_ENV=${BUILD_ENV}
-PATH=${BUILD_ENV}/ROOT/OCAML/bin:$PATH
-eval `${BUILD_ENV}/ROOT/OPAM/bin/opam config env -r ${BUILD_ENV}/ROOT/OPAM_ROOT`
+eval `opam config env`
 
 
 ocamlfind printconf

--- a/jenkins/run-lxc.sh
+++ b/jenkins/run-lxc.sh
@@ -1,0 +1,136 @@
+#!/bin/bash -xue
+
+JOB=$1
+BASE=$2
+
+if [ -z $JOB ];
+then
+    echo "\$JOB not set"
+    exit 1
+fi
+if [ -z $BASE ];
+then
+    echo "\$BASE not set"
+    exit 1
+fi
+
+if [ ! -r jenkins/$JOB/seed ];
+then
+    echo "Seed file jenkins/$JOB/seed not readable"
+    exit 1
+fi
+
+SEED=`cat jenkins/$JOB/seed`
+# Relative to $BASE
+SEEDS_BASE=seeds
+JOBS_BASE=jobs
+ROOTFS=$BASE/$JOBS_BASE/$BUILD_TAG
+CONTAINER_USER=jenkinslxc
+
+if [ ! -d $BASE/$SEEDS_BASE/$SEED ];
+then
+    echo "Seed subvolume '$SEED' not found"
+    exit 1
+fi
+
+echo "Create seed snapshot"
+pushd $BASE
+sudo /sbin/btrfs subvolume snapshot $SEEDS_BASE/$SEED $JOBS_BASE/$BUILD_TAG
+popd
+
+echo "Fixup clone files"
+pushd $ROOTFS
+sudo /bin/chown jenkins etc/hosts
+sudo /bin/chown jenkins etc
+sed -i "s/localhost/$BUILD_TAG localhost/" etc/hosts
+sudo /bin/chown root:root etc/hosts
+sudo /bin/chown root:root etc
+popd
+
+LXC_CONF_NAME=lxc-$BUILD_TAG.conf
+LXC_CONF=$ROOTFS/$LXC_CONF_NAME
+
+echo "Creating LXC configuration file"
+cat > $LXC_CONF_NAME << EOF
+lxc.utsname=$BUILD_TAG
+
+lxc.network.type=veth
+lxc.network.flags=down
+lxc.network.link=lxcbr0
+lxc.network.name=eth0
+
+lxc.rootfs=$ROOTFS
+
+lxc.mount.entry=$WORKSPACE $ROOTFS/home/$CONTAINER_USER/workspace bind bind,nodev,nosuid 0 0
+
+lxc.tty = 4
+lxc.pts = 1024
+lxc.cgroup.devices.deny = a
+# /dev/null and zero
+lxc.cgroup.devices.allow = c 1:3 rwm
+lxc.cgroup.devices.allow = c 1:5 rwm
+# consoles
+lxc.cgroup.devices.allow = c 5:1 rwm
+lxc.cgroup.devices.allow = c 5:0 rwm
+lxc.cgroup.devices.allow = c 4:0 rwm
+lxc.cgroup.devices.allow = c 4:1 rwm
+# /dev/{,u}random
+lxc.cgroup.devices.allow = c 1:9 rwm
+lxc.cgroup.devices.allow = c 1:8 rwm
+lxc.cgroup.devices.allow = c 136:* rwm
+lxc.cgroup.devices.allow = c 5:2 rwm
+# rtc
+lxc.cgroup.devices.allow = c 254:0 rwm
+
+# mounts point
+lxc.mount.entry=proc $ROOTFS/proc proc nodev,noexec,nosuid 0 0
+lxc.mount.entry=devpts $ROOTFS/dev/pts devpts defaults 0 0
+lxc.mount.entry=sysfs $ROOTFS/sys sysfs defaults  0 0
+EOF
+
+sudo chown root:root $LXC_CONF_NAME
+sudo mv $LXC_CONF_NAME $LXC_CONF
+
+echo "Write job execution script"
+JOB_SCRIPT_NAME=job-$BUILD_TAG.sh
+
+cat > $JOB_SCRIPT_NAME << EOF
+#!/bin/bash -xue
+
+sudo /sbin/ifconfig lo up
+# Make sure no daemon keeps running!
+sudo /sbin/dhclient eth0
+trap "{ sudo /sbin/dhclient -r eth0; }" EXIT
+
+/sbin/ifconfig
+/sbin/route -n
+
+# Re-export some of the Jenkins env
+export BUILD_NUMBER=$BUILD_NUMBER
+export BUILD_ID=$BUILD_ID
+export JOB_NAME=$JOB_NAME
+export BUILD_TAG=$BUILD_TAG
+
+export WORKSPACE=\$HOME/workspace
+
+export JOB=$JOB
+
+cd \$HOME/workspace
+
+for script in \`ls jenkins/\$JOB/* | grep -e "\/[0-9]\{3\}_"\`; do
+    cd "\$WORKSPACE"
+    \$script
+done
+
+ps afx
+
+EOF
+
+echo "Move job execution script into container"
+sudo /bin/chown root:root $JOB_SCRIPT_NAME
+sudo /bin/mv $JOB_SCRIPT_NAME $ROOTFS/home/$CONTAINER_USER
+
+echo "Run job"
+sudo /usr/bin/lxc-execute -n $BUILD_TAG -f $LXC_CONF -- su - $CONTAINER_USER -c "/bin/bash -xue /home/$CONTAINER_USER/$JOB_SCRIPT_NAME"
+
+exit $?

--- a/jenkins/system_tests_quick/010_install_sandbox.sh
+++ b/jenkins/system_tests_quick/010_install_sandbox.sh
@@ -1,4 +1,0 @@
-sudo rm -rf /opt/qbase3
-sudo tar xfz /home/qbase/qbaseSandbox_3.2-small-linux64.tar.gz -C /opt
-sudo cp /home/qbase/sources/publish.cfg /opt/qbase3/cfg/qpackages4/sources.cfg
-sudo cp /home/qbase/hgconnection.cfg /opt/qbase3/cfg/qconfig/hgconnection.cfg

--- a/jenkins/system_tests_quick/020_update_qpackages.sh
+++ b/jenkins/system_tests_quick/020_update_qpackages.sh
@@ -1,3 +1,5 @@
-sudo /opt/qbase3/qshell -c "
+#!/bin/bash -xue
+
+/opt/qbase3/qshell -c "
 i.qp.updateAll()
 "

--- a/jenkins/system_tests_quick/030_prepare_system_tests.sh
+++ b/jenkins/system_tests_quick/030_prepare_system_tests.sh
@@ -1,2 +1,4 @@
-sudo /opt/qbase3/qshell ./jenkins/prepareSystemTests.py
-sudo mkdir -p ${WORKSPACE}/testresults
+#!/bin/bash -xue
+
+/opt/qbase3/qshell ./jenkins/prepareSystemTests.py
+mkdir -p ${WORKSPACE}/testresults

--- a/jenkins/system_tests_quick/050_run_pending_configuration.sh
+++ b/jenkins/system_tests_quick/050_run_pending_configuration.sh
@@ -1,3 +1,5 @@
-sudo /opt/qbase3/qshell -c "
+#!/bin/bash -xue
+
+/opt/qbase3/qshell -c "
 q.qp._runPendingReconfigeFiles()
 "

--- a/jenkins/system_tests_quick/060_install_nose.sh
+++ b/jenkins/system_tests_quick/060_install_nose.sh
@@ -1,13 +1,15 @@
+#!/bin/bash -xue
+
 echo "Install nose utilities in QBase"
 
 test -f /tmp/coverage-3.4b2.tar.gz || wget -q -O /tmp/coverage-3.4b2.tar.gz http://pypi.python.org/packages/source/c/coverage/coverage-3.4b2.tar.gz
-sudo /opt/qbase3/bin/easy_install /tmp/coverage-3.4b2.tar.gz
+/opt/qbase3/bin/easy_install /tmp/coverage-3.4b2.tar.gz
 
 test -f /tmp/nosexcover-1.0.4.tar.gz || wget -q -O /tmp/nosexcover-1.0.4.tar.gz http://pypi.python.org/packages/source/n/nosexcover/nosexcover-1.0.4.tar.gz
-sudo /opt/qbase3/bin/easy_install /tmp/nosexcover-1.0.4.tar.gz
+/opt/qbase3/bin/easy_install /tmp/nosexcover-1.0.4.tar.gz
 
-sudo rm -f ${WORKSPACE}/coverage.xml
-sudo rm -f /opt/qbase3/var/tests/coverage.xml
+rm -f ${WORKSPACE}/coverage.xml
+rm -f /opt/qbase3/var/tests/coverage.xml
 
 cd ${WORKSPACE}
 mkdir -p _tools

--- a/jenkins/system_tests_quick/070_run_tests.sh
+++ b/jenkins/system_tests_quick/070_run_tests.sh
@@ -1,4 +1,6 @@
-sudo /opt/qbase3/qshell -c "
+#!/bin/bash -xue
+
+/opt/qbase3/qshell -c "
 
 q.testrunner.list()
 
@@ -24,7 +26,7 @@ q.testrunner._runTests(arguments)
 
 RESULT=$?
 
-test -f /opt/qbase3/var/tests/coverage.xml && sudo mv /opt/qbase3/var/tests/coverage.xml ${WORKSPACE}/coverage.xml
+test -f /opt/qbase3/var/tests/coverage.xml && mv /opt/qbase3/var/tests/coverage.xml ${WORKSPACE}/coverage.xml
 
 cat ${WORKSPACE}/coverage.xml | python ${WORKSPACE}/_tools/fix_coverage.py "${WORKSPACE}" ".opt.qbase3.lib.python.site-packages." ".var.hudson.workspace.pyrakoon-tip-system-tests.python_env.pyrakoon." > ${WORKSPACE}/coverage_fixed.xml
 

--- a/jenkins/system_tests_quick/seed
+++ b/jenkins/system_tests_quick/seed
@@ -1,0 +1,1 @@
+arakoon-1.x-qbase3-ubuntu-12.10-quantal-20130304

--- a/jenkins/system_tests_slow_left/010_install_sandbox.sh
+++ b/jenkins/system_tests_slow_left/010_install_sandbox.sh
@@ -1,4 +1,0 @@
-sudo rm -rf /opt/qbase3
-sudo tar xfz /home/qbase/qbaseSandbox_3.2-small-linux64.tar.gz -C /opt
-sudo cp /home/qbase/sources/publish.cfg /opt/qbase3/cfg/qpackages4/sources.cfg
-sudo cp /home/qbase/hgconnection.cfg /opt/qbase3/cfg/qconfig/hgconnection.cfg

--- a/jenkins/system_tests_slow_left/020_update_qpackages.sh
+++ b/jenkins/system_tests_slow_left/020_update_qpackages.sh
@@ -1,3 +1,5 @@
-sudo /opt/qbase3/qshell -c "
+#!/bin/bash -xue
+
+/opt/qbase3/qshell -c "
 i.qp.updateAll()
 "

--- a/jenkins/system_tests_slow_left/030_prepare_system_tests.sh
+++ b/jenkins/system_tests_slow_left/030_prepare_system_tests.sh
@@ -1,3 +1,5 @@
-sudo /opt/qbase3/qshell ./jenkins/prepareSystemTests.py
+#!/bin/bash -xue
 
-sudo mkdir -p ${WORKSPACE}/testresults
+/opt/qbase3/qshell ./jenkins/prepareSystemTests.py
+
+mkdir -p ${WORKSPACE}/testresults

--- a/jenkins/system_tests_slow_left/050_run_pending_configuration.sh
+++ b/jenkins/system_tests_slow_left/050_run_pending_configuration.sh
@@ -1,3 +1,5 @@
-sudo /opt/qbase3/qshell -c "
+#!/bin/bash -xue
+
+/opt/qbase3/qshell -c "
 q.qp._runPendingReconfigeFiles()
 "

--- a/jenkins/system_tests_slow_left/060_install_nose.sh
+++ b/jenkins/system_tests_slow_left/060_install_nose.sh
@@ -1,13 +1,15 @@
+#!/bin/bash -xue
+
 echo "Install nose utilities in QBase"
 
 test -f /tmp/coverage-3.4b2.tar.gz || wget -q -O /tmp/coverage-3.4b2.tar.gz http://pypi.python.org/packages/source/c/coverage/coverage-3.4b2.tar.gz
-sudo /opt/qbase3/bin/easy_install /tmp/coverage-3.4b2.tar.gz
+/opt/qbase3/bin/easy_install /tmp/coverage-3.4b2.tar.gz
 
 test -f /tmp/nosexcover-1.0.4.tar.gz || wget -q -O /tmp/nosexcover-1.0.4.tar.gz http://pypi.python.org/packages/source/n/nosexcover/nosexcover-1.0.4.tar.gz
-sudo /opt/qbase3/bin/easy_install /tmp/nosexcover-1.0.4.tar.gz
+/opt/qbase3/bin/easy_install /tmp/nosexcover-1.0.4.tar.gz
 
-sudo rm -f ${WORKSPACE}/coverage.xml
-sudo rm -f /opt/qbase3/var/tests/coverage.xml
+rm -f ${WORKSPACE}/coverage.xml
+rm -f /opt/qbase3/var/tests/coverage.xml
 
 cd ${WORKSPACE}
 mkdir -p _tools

--- a/jenkins/system_tests_slow_left/070_run_tests.sh
+++ b/jenkins/system_tests_slow_left/070_run_tests.sh
@@ -1,4 +1,6 @@
-sudo /opt/qbase3/qshell -c "
+#!/bin/bash -xue
+
+/opt/qbase3/qshell -c "
 q.testrunner.list()
 
 test_spec = 'arakoon_system_tests.server.left'
@@ -25,7 +27,7 @@ q.testrunner._runTests(arguments)
 
 RESULT=$?
 
-test -f /opt/qbase3/var/tests/coverage.xml && sudo mv /opt/qbase3/var/tests/coverage.xml ${WORKSPACE}/coverage.xml
+test -f /opt/qbase3/var/tests/coverage.xml && mv /opt/qbase3/var/tests/coverage.xml ${WORKSPACE}/coverage.xml
 
 cat ${WORKSPACE}/coverage.xml | python ${WORKSPACE}/_tools/fix_coverage.py "${WORKSPACE}" ".opt.qbase3.lib.python.site-packages." ".var.hudson.workspace.pyrakoon-tip-system-tests.python_env.pyrakoon." > ${WORKSPACE}/coverage_fixed.xml
 

--- a/jenkins/system_tests_slow_left/seed
+++ b/jenkins/system_tests_slow_left/seed
@@ -1,0 +1,1 @@
+arakoon-1.x-qbase3-ubuntu-12.10-quantal-20130304

--- a/jenkins/system_tests_slow_right/010_install_sandbox.sh
+++ b/jenkins/system_tests_slow_right/010_install_sandbox.sh
@@ -1,4 +1,0 @@
-sudo rm -rf /opt/qbase3
-sudo tar xfz /home/qbase/qbaseSandbox_3.2-small-linux64.tar.gz -C /opt
-sudo cp /home/qbase/sources/publish.cfg /opt/qbase3/cfg/qpackages4/sources.cfg
-sudo cp /home/qbase/hgconnection.cfg /opt/qbase3/cfg/qconfig/hgconnection.cfg

--- a/jenkins/system_tests_slow_right/020_update_qpackages.sh
+++ b/jenkins/system_tests_slow_right/020_update_qpackages.sh
@@ -1,3 +1,5 @@
-sudo /opt/qbase3/qshell -c "
+#!/bin/bash -xue
+
+/opt/qbase3/qshell -c "
 i.qp.updateAll()
 "

--- a/jenkins/system_tests_slow_right/030_prepare_system_tests.sh
+++ b/jenkins/system_tests_slow_right/030_prepare_system_tests.sh
@@ -1,3 +1,5 @@
-sudo /opt/qbase3/qshell ./jenkins/prepareSystemTests.py
+#!/bin/bash -xue
 
-sudo mkdir -p ${WORKSPACE}/testresults
+/opt/qbase3/qshell ./jenkins/prepareSystemTests.py
+
+mkdir -p ${WORKSPACE}/testresults

--- a/jenkins/system_tests_slow_right/050_run_pending_configuration.sh
+++ b/jenkins/system_tests_slow_right/050_run_pending_configuration.sh
@@ -1,3 +1,5 @@
-sudo /opt/qbase3/qshell -c "
+#!/bin/bash -xue
+
+/opt/qbase3/qshell -c "
 q.qp._runPendingReconfigeFiles()
 "

--- a/jenkins/system_tests_slow_right/060_install_nose.sh
+++ b/jenkins/system_tests_slow_right/060_install_nose.sh
@@ -1,13 +1,15 @@
+#!/bin/bash -xue
+
 echo "Install nose utilities in QBase"
 
 test -f /tmp/coverage-3.4b2.tar.gz || wget -q -O /tmp/coverage-3.4b2.tar.gz http://pypi.python.org/packages/source/c/coverage/coverage-3.4b2.tar.gz
-sudo /opt/qbase3/bin/easy_install /tmp/coverage-3.4b2.tar.gz
+/opt/qbase3/bin/easy_install /tmp/coverage-3.4b2.tar.gz
 
 test -f /tmp/nosexcover-1.0.4.tar.gz || wget -q -O /tmp/nosexcover-1.0.4.tar.gz http://pypi.python.org/packages/source/n/nosexcover/nosexcover-1.0.4.tar.gz
-sudo /opt/qbase3/bin/easy_install /tmp/nosexcover-1.0.4.tar.gz
+/opt/qbase3/bin/easy_install /tmp/nosexcover-1.0.4.tar.gz
 
-sudo rm -f ${WORKSPACE}/coverage.xml
-sudo rm -f /opt/qbase3/var/tests/coverage.xml
+rm -f ${WORKSPACE}/coverage.xml
+rm -f /opt/qbase3/var/tests/coverage.xml
 
 cd ${WORKSPACE}
 mkdir -p _tools

--- a/jenkins/system_tests_slow_right/070_run_tests.sh
+++ b/jenkins/system_tests_slow_right/070_run_tests.sh
@@ -1,4 +1,6 @@
-sudo /opt/qbase3/qshell -c "
+#!/bin/bash -xue
+
+/opt/qbase3/qshell -c "
 q.testrunner.list()
 
 test_spec = 'arakoon_system_tests.server.right.system_tests_long_right'
@@ -22,7 +24,7 @@ q.testrunner._runTests(arguments)
 
 RESULT=$?
 
-test -f /opt/qbase3/var/tests/coverage.xml && sudo mv /opt/qbase3/var/tests/coverage.xml ${WORKSPACE}/coverage.xml
+test -f /opt/qbase3/var/tests/coverage.xml && mv /opt/qbase3/var/tests/coverage.xml ${WORKSPACE}/coverage.xml
 
 cat ${WORKSPACE}/coverage.xml | python ${WORKSPACE}/_tools/fix_coverage.py "${WORKSPACE}" ".opt.qbase3.lib.python.site-packages." ".var.hudson.workspace.pyrakoon-tip-system-tests.python_env.pyrakoon." > ${WORKSPACE}/coverage_fixed.xml
 

--- a/jenkins/system_tests_slow_right/seed
+++ b/jenkins/system_tests_slow_right/seed
@@ -1,0 +1,1 @@
+arakoon-1.x-qbase3-ubuntu-12.10-quantal-20130304


### PR DESCRIPTION
These commits rework the Jenkins/CI setup to use LXC containers (see http://confluence.incubaid.com/display/ENG/Setup+of+cislave11 for more information about the setup).

Some tests might still fail (due to missing permissions since no longer running as root?), but it would be useful to merge the current changes as-is so the 1.6 jobs can be put in place.
