### PR TITLE
no fsync for tlogs (invalid operation)

### DIFF
--- a/extension/test/server/quick/TestCmdTools.py
+++ b/extension/test/server/quick/TestCmdTools.py
@@ -68,6 +68,20 @@ class TestCmdTools:
         for key in status.keys():
             if status[key] == q.enumerators.AppStatusType.RUNNING:
                 c = c + 1
+        if c != n:
+            for key in status.keys():
+                if status[key] == q.enumerators.AppStatusType.HALTED:
+                    cfg = cluster._getConfigFile()
+                    logDir = cfg.getValue(key, "log_dir")
+                    fn = "%s/%s.log" % (logDir, key)
+                    logging.info("fn=%s",fn)
+                    with open(fn,'r') as f:
+                        lines = f.readlines()
+                        logging.info("log file for %s", key)
+                        for l in lines:
+                            ls = l.strip()
+                            logging.info(ls)
+
         assert_equals(c, n)
 
     def testStart(self):

--- a/extension/test/server/right/system_tests_preferred_masters.py
+++ b/extension/test/server/right/system_tests_preferred_masters.py
@@ -152,7 +152,7 @@ def test_prefered_masters():
         assert master in preferred_masters_2
 
         logging.info('Killing master')
-        cluster.stopNode(master)
+        cluster.stopOne(master)
         preferred_masters_2.remove(master)
 
         logging.debug('Waiting for things to settle')

--- a/src/tlog/tlc2.ml
+++ b/src/tlog/tlc2.ml
@@ -604,7 +604,6 @@ object(self: # tlog_collection)
                   (Log_extra.string_option2s marker) (Sn.string_of i) node_id  
               end
       end >>= fun () ->
-      F.fsync file >>= fun () ->
       F.close file 
     end
 


### PR DESCRIPTION
better logging for nodes that didn't start
stopNode -> stopOne
