### PR TITLE
Transaction changes

### DIFF
--- a/src/all_test.ml
+++ b/src/all_test.ml
@@ -56,6 +56,7 @@ let tlog_tests = "tlogs" >::: [
   Tlogreader2_test.suite;
 ]
 let small_catchup = "small_catchup" >:::[Catchup_test.suite;]
+let store = "store" >:::[Store_test.suite;]
 let compression = "compression" >::: [Compression_test.suite;]
 let collapser   = "collapser" >::: [Collapser_test.suite]
 let crc32c_tests = "crc32c" >::: [Crc32c_test.suite]
@@ -89,6 +90,6 @@ let suite = "universe" >::: [
   collapser;
   system;
   nursery; 
-
+  store;
 ]
 

--- a/src/node/catchup.ml
+++ b/src/node/catchup.ml
@@ -171,7 +171,7 @@ let catchup_store me (store,tlog_coll) (too_far_i:Sn.t) =
         else
           Lwt.return ()
     in
-    let f entry =
+    let f tx entry =
       let i = Entry.i_of entry 
       and value = Entry.v_of entry 
       in
@@ -188,7 +188,7 @@ let catchup_store me (store,tlog_coll) (too_far_i:Sn.t) =
 		             a node in catchup thinks it's master due to 
 		             some lease starting in the past *)
 		          let pv' = Value.clear_master_set pv in
-		          Store.safe_insert_value store pi pv' >>= fun _ ->
+		          Store.safe_insert_value ~tx store pi pv' >>= fun _ ->
 		          let () = acc := Some(i,value) in
 		          Lwt.return ()
 		        end
@@ -199,13 +199,53 @@ let catchup_store me (store,tlog_coll) (too_far_i:Sn.t) =
 		          Lwt.return ()
 		        end
     in
-    tlog_coll # iterate start_i too_far_i f >>= fun () ->
+    (* try to batch transactions to speedup the process *)
+    let batch = Queue.create ()
+    and batch_i = ref 0 in
+    let iter_batch () =
+      let current_acc = !acc in
+      Lwt.catch
+        (fun () ->
+          Lwt_log.info "trying batched transactions" >>= fun () ->
+          store # with_transaction (fun tx ->
+            Queue.fold (fun acc tlogentry -> acc >>= (fun () -> f (Some tx) tlogentry)) (Lwt.return ()) batch)
+          >>= fun () ->
+          Queue.clear batch;
+          Lwt.return ())
+        (fun _ ->
+          let rec inner () =
+            if Queue.is_empty batch
+            then Lwt.return ()
+            else
+              f None (Queue.take batch) >>= (fun () -> inner ()) in
+          Lwt_log.info "batching transactions failed; going back to not batched mode" >>= fun () ->
+          acc := current_acc;
+          inner ()) in
+    let batched_f tlogentry =
+      let r =
+        if !batch_i < 1000
+        then
+          begin
+            batch_i := !batch_i + 1;
+            Lwt.return ()
+          end
+        else
+          begin
+            let r = iter_batch () in
+            batch_i := 0;
+            r
+          end in
+      Queue.add tlogentry batch;
+      r
+    in
+    tlog_coll # iterate start_i too_far_i batched_f >>= fun () ->
+    iter_batch () >>= fun () ->
     begin
       match !acc with 
         | None -> Lwt.return ()
         | Some(i,value) -> 
-          Lwt_log.debug_f "%s => store" (Sn.string_of i) >>= fun () ->
-          Store.safe_insert_value store i value >>= fun _ -> Lwt.return ()
+            Lwt_log.debug_f "%s => store" (Sn.string_of i) >>= fun () ->
+            Store.safe_insert_value store i value >>= fun _ -> Lwt.return ()
     end >>= fun () -> 
     let store_i' = store # consensus_i () in
     Lwt_log.info_f "catchup_store completed, store is @ %s" 

--- a/src/node/catchup_test.ml
+++ b/src/node/catchup_test.ml
@@ -172,7 +172,9 @@ let test_batched_with_failures () =
       assert_not_exists "_3a_key2530" >>= fun () ->
       assert_not_exists "_3b_key2530")
 
-
+let test_large_tlog_catchup () =
+  _tic _fill 100_000 "tcs"
+    (fun store new_i -> Lwt.return ())
 
 let suite =
   let w f = lwt_bracket setup f teardown in
@@ -181,5 +183,6 @@ let suite =
     "with_doubles" >:: w test_with_doubles;
     "interrupted_catchup" >:: w test_interrupted_catchup;
     "batched_with_failures" >:: w test_batched_with_failures;
+    "large_tlog_catchup" >:: w test_large_tlog_catchup;
   ]
 

--- a/src/node/catchup_test.ml
+++ b/src/node/catchup_test.ml
@@ -67,6 +67,32 @@ let _fill2 tlog_coll n =
   in
   _loop 0
 
+let _fill3 tlog_coll n =
+  let sync = false in
+  let rec _loop i =
+    if i = n then Lwt.return ()
+    else
+      begin
+        let k = Printf.sprintf "_3a_key%i" i
+        and v = Printf.sprintf "_3a_value%i" i
+        and k2 = Printf.sprintf "key%i" i
+        and v2 = Printf.sprintf "value%i" i
+        and k3 = Printf.sprintf "_3b_key%i" i
+        and v3 = Printf.sprintf "_3b_value%i" i
+        in
+        let u = Update.Set(k,v) in
+        let u2 = Update.Set(k2,v2) in
+        let u3 = Update.Sequence [Update.Set(k3,v3); Update.Assert_exists("nonExistingKey")] in
+        let value = Value.create_client_value [u; u3] sync in
+        let value2 = Value.create_client_value [u2; u3] sync in
+        let sni = Sn.of_int i in
+        tlog_coll # log_value sni value  >>= fun () ->
+        tlog_coll # log_value sni value2 >>= fun () ->
+        _loop (i+1)
+      end
+  in
+  _loop 0
+
 let setup () = 
   Lwt_log.info "Catchup_test.setup" >>= fun () ->
   let ignore_ex f = 
@@ -104,16 +130,17 @@ let teardown () =
     >>= fun () ->
   Lwt_log.debug "end of teardown"
 
-let _tic filler_function name =
-  Tlogcommon.tlogEntriesPerFile := 101; 
+let _tic filler_function n name verify_store =
+  Tlogcommon.tlogEntriesPerFile := 101;
   Tlc2.make_tlc2 _dir_name true "node_name" >>= fun tlog_coll ->
-  filler_function tlog_coll 1000 >>= fun () ->
-  let tlog_i = Sn.of_int 1000 in 
+  filler_function tlog_coll n >>= fun () ->
+  let tlog_i = Sn.of_int n in
   let db_name = _dir_name ^ "/" ^ name ^ ".db" in
   Local_store.make_local_store db_name >>= fun store ->
   let me = "??me??" in
   Catchup.verify_n_catchup_store me (store, tlog_coll, Some tlog_i) tlog_i None
   >>= fun (new_i,vo) ->
+  verify_store store new_i >>= fun () ->
   Lwt_log.info_f "new_i=%s" (Sn.string_of new_i) >>= fun () ->
   tlog_coll # close () >>= fun () -> 
   store # close () 
@@ -122,18 +149,37 @@ let _tic filler_function name =
 
 let test_interrupted_catchup () =
   Lwt_log.info "test_interrupted_catchup" >>= fun () ->
-  _tic _fill "tic"
+  _tic _fill 1000 "tic" (fun store new_i -> Lwt.return ())
 
 
 let test_with_doubles () =
   Lwt_log.info "test_with_doubles" >>= fun () ->
-  _tic _fill2 "twd"
+  _tic _fill2 1000 "twd" (fun store new_i -> Lwt.return ())
 
-let suite = 
+
+let test_batched_with_failures () =
+  Lwt_log.info "test_batched_with_failures" >>= fun () ->
+  _tic _fill3 3000 "tbwf"
+    (fun store new_i ->
+      let assert_not_exists k = store # exists k >>= fun exists -> if exists then failwith "found key that is not supposed to be in the store!" else Lwt.return () in
+      let assert_exists k = store # exists k >>= fun exists -> if not exists then failwith "could not find required key in the store!" else Lwt.return () in
+      assert_exists "key2" >>= fun () ->
+      assert_exists "key2590" >>= fun () ->
+      assert_not_exists "_3a_key2" >>= fun () ->
+      assert_not_exists "_3b_key2" >>= fun () ->
+      assert_not_exists "_3a_key200" >>= fun () ->
+      assert_not_exists "_3b_key200" >>= fun () ->
+      assert_not_exists "_3a_key2530" >>= fun () ->
+      assert_not_exists "_3b_key2530")
+
+
+
+let suite =
   let w f = lwt_bracket setup f teardown in
   "catchup" >:::[
     "common" >:: w test_common;
-    "with_doubles" >:: w test_with_doubles; 
+    "with_doubles" >:: w test_with_doubles;
     "interrupted_catchup" >:: w test_interrupted_catchup;
-
+    "batched_with_failures" >:: w test_batched_with_failures;
   ]
+

--- a/src/node/local_store.ml
+++ b/src/node/local_store.ml
@@ -392,11 +392,6 @@ object(self: #store)
                 (fun () -> _set_j db (new_j j); Lwt.return ())) >>= fun a ->
               Lwt.return a
 
-  method private _do_locked : 'a. (Camltc.Hotc.bdb -> 'a Lwt.t) -> 'a Lwt.t = fun f ->
-    match _tx with
-      | None -> self # with_transaction ~key:_tx_lock (fun tx -> self # _with_tx tx f (fun j -> j))
-      | Some (tx, bdb) -> f bdb
-
   method private _update_in_tx : 'a. transaction -> (Camltc.Hotc.bdb -> 'a Lwt.t) -> 'a Lwt.t =
     fun tx f ->
       self # _with_tx tx f ((+) 1)
@@ -423,9 +418,9 @@ object(self: #store)
         Lwt.finalize
           (fun () ->
             Camltc.Hotc.transaction db
-              (fun bdb ->
+              (fun db ->
                 let tx = new transaction in
-                _tx <- Some (tx, bdb);
+                _tx <- Some (tx, db);
 
                 let t0 = Unix.gettimeofday() in
                 f tx >>= fun a ->
@@ -530,19 +525,19 @@ object(self: #store)
 	| exn -> Lwt.fail exn)
 
   method multi_get ?(_pf = __prefix) keys =
-    self # _do_locked (fun bdb ->
-      let vs = List.fold_left
-	    (fun acc key ->
-	      try
-	        let v = B.get bdb (_pf ^ key) in
-	        v::acc
-	      with Not_found ->
-	        let exn = Common.XException(Arakoon_exc.E_NOT_FOUND,key) in
-	        raise exn
-	    )
-	    [] keys
-	  in
-	  Lwt.return (List.rev vs))
+    let bdb = Camltc.Hotc.get_bdb db in
+    let vs = List.fold_left
+	  (fun acc key ->
+	    try
+	      let v = B.get bdb (_pf ^ key) in
+	      v::acc
+	    with Not_found ->
+	      let exn = Common.XException(Arakoon_exc.E_NOT_FOUND,key) in
+	      raise exn
+	  )
+	  [] keys
+	in
+	Lwt.return (List.rev vs)
 
   method private _incr_i_cached () =
     let incr =
@@ -565,28 +560,25 @@ object(self: #store)
 
 
   method range ?(_pf=__prefix) first finc last linc max =
-    self # _do_locked (fun bdb ->
-      Lwt.return (B.range bdb (_f _pf first) finc (_l _pf last) linc max) >>= fun r ->
-      Lwt.return (_filter _pf r))
+    let bdb = Camltc.Hotc.get_bdb db in
+    Lwt.return (B.range bdb (_f _pf first) finc (_l _pf last) linc max) >>= fun r ->
+    Lwt.return (_filter _pf r)
 
   method range_entries ?(_pf=__prefix) first finc last linc max =
-    self # _do_locked (fun bdb ->
-      let r = _range_entries _pf bdb first finc last linc max in
-      Lwt.return r)
+    let bdb = Camltc.Hotc.get_bdb db in
+    let r = _range_entries _pf bdb first finc last linc max in
+    Lwt.return r
 
   method rev_range_entries ?(_pf=__prefix) first finc last linc max =
-    self # _do_locked (fun bdb ->
-      let r = B.rev_range_entries _pf bdb first finc last linc max in
-      Lwt.return r)
-
-  method private _prefix_keys bdb _pf prefix max =
-      let keys_array = B.prefix_keys bdb (_pf ^ prefix) max in
-	  let keys_list = _filter _pf keys_array in
-	  Lwt.return keys_list
+    let bdb = Camltc.Hotc.get_bdb db in
+    let r = B.rev_range_entries _pf bdb first finc last linc max in
+    Lwt.return r
 
   method prefix_keys ?(_pf=__prefix) prefix max =
-    self # _do_locked (fun bdb ->
-      self # _prefix_keys bdb _pf prefix max)
+    let bdb = Camltc.Hotc.get_bdb db in
+    let keys_array = B.prefix_keys bdb (_pf ^ prefix) max in
+	let keys_list = _filter _pf keys_array in
+	Lwt.return keys_list
 
   method set tx ?(_pf=__prefix) key value =
     self # _wrap_exception "set"
@@ -713,12 +705,11 @@ object(self: #store)
 
   method get_key_count ?(_pf=__prefix) () =
     Lwt_log.debug "local_store::get_key_count" >>= fun () ->
-    self # _do_locked (fun bdb ->
-      let raw_count = B.get_key_count bdb in
-      (* Leave out administrative keys *)
-      self # _prefix_keys bdb __adminprefix "" (-1) >>= fun admin_keys ->
-      let admin_key_count = List.length admin_keys in
-      Lwt.return ( Int64.sub raw_count (Int64.of_int admin_key_count) ))
+    Camltc.Hotc.transaction db (fun db -> Lwt.return ( B.get_key_count db ) ) >>= fun raw_count ->
+    (* Leave out administrative keys *)
+    self # prefix_keys ~_pf:__adminprefix "" (-1) >>= fun admin_keys ->
+    let admin_key_count = List.length admin_keys in
+    Lwt.return ( Int64.sub raw_count (Int64.of_int admin_key_count) )
 
   method copy_store ?(_networkClient=true) (oc: Lwt_io.output_channel) =
     if _quiesced 

--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -200,13 +200,13 @@ module X = struct
 	 the idea is to lift stuff out of _main_2 
       *)
   
-  let on_consensus store vni =
+  let on_consensus (store:Store.store) vni =
     let (v,n,i) = vni in
     begin
       if Value.is_master_set v
-      then 
+      then
 	    begin
-	      store # incr_i () >>= fun () -> 
+	      store # with_transaction (fun tx -> store # incr_i tx) >>= fun () ->
           Lwt.return [Store.Ok None]
 	    end
       else

--- a/src/node/store_test.ml
+++ b/src/node/store_test.ml
@@ -1,0 +1,128 @@
+(*
+This file is part of Arakoon, a distributed key-value store. Copyright
+(C) 2010 Incubaid BVBA
+
+Licensees holding a valid Incubaid license may use this file in
+accordance with Incubaid's Arakoon commercial license agreement. For
+more information on how to enter into this agreement, please contact
+Incubaid (contact details can be found on www.arakoon.org/licensing).
+
+Alternatively, this file may be redistributed and/or modified under
+the terms of the GNU Affero General Public License version 3, as
+published by the Free Software Foundation. Under this license, this
+file is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU Affero General Public License for more details.
+You should have received a copy of the
+GNU Affero General Public License along with this program (file "COPYING").
+If not, see <http://www.gnu.org/licenses/>.
+*)
+
+open OUnit
+open Lwt
+open Extra
+open Update
+
+let _dir_name = "/tmp/store_test"
+
+let setup () = 
+  Lwt_log.info "Store_test.setup" >>= fun () ->
+  let ignore_ex f = 
+    Lwt.catch 
+      f
+      (fun exn -> Lwt_log.warning ~exn "ignoring")
+  in
+  ignore_ex (fun () -> File_system.rmdir _dir_name) >>= fun () ->
+  ignore_ex (fun () -> File_system.mkdir  _dir_name 0o750 )
+
+let teardown () = 
+  Lwt_log.info "Store_test.teardown" >>= fun () ->
+  Lwt.catch
+    (fun () ->
+      File_system.lwt_directory_list _dir_name >>= fun entries ->
+      Lwt_list.iter_s (fun i -> 
+	let fn = _dir_name ^ "/" ^ i in
+        Lwt_unix.unlink fn) entries 
+    )
+    (fun exn -> Lwt_log.debug ~exn "ignoring" )
+    >>= fun () ->
+  Lwt_log.debug "end of teardown"
+
+let with_store name f =
+  let db_name = _dir_name ^ "/" ^ name ^ ".db" in
+  Local_store.make_local_store db_name >>= fun store ->
+  f store >>= fun () ->
+  store # close ()
+
+let assert_k_v k v (store:Store.store) =
+  store # get k >>= fun av ->
+  if v <> av then failwith "not as expected" else Lwt.return ()
+
+let assert_not_exists k (store:Store.store) =
+  store # exists k >>= fun exists ->
+  if exists then failwith "key should not exist" else Lwt.return ()
+
+let failing_value =
+  let k2 = "key2"
+  and v2 = "value2" in
+  Value.create_client_value [Update.Sequence [Update.Set(k2, v2);
+                                              Update.Assert_exists "notExists"]] false
+
+
+let value_asserts =
+  let k1 = "key1"
+  and v1 = "value1" in
+  [(Value.create_client_value [Update.Set(k1,v1)] false,
+    [assert_k_v k1 v1]);
+   (failing_value,
+    [assert_not_exists "key2"]);]
+
+let test_safe_insert_value () =
+  let get_next_i store = match store # consensus_i () with
+    | None -> Sn.of_int 0
+    | Some i -> Sn.succ i in
+  let do_asserts store =
+    Lwt_list.iter_s
+      (fun (value, asserts) ->
+        Store.safe_insert_value store (get_next_i store) value >>= fun _ ->
+        Lwt_list.iter_s
+          (fun assert' -> assert' store)
+          asserts)
+      value_asserts in
+  Lwt_log.info "applying updates without surrounding transaction" >>= fun () ->
+  with_store "tsiv" (fun store ->
+    do_asserts store)
+
+let test_safe_insert_value_with_tx () =
+  with_store "tsivwt" (fun store ->
+    store # with_transaction (fun tx ->
+      (Lwt.catch
+         (fun () -> Store.safe_insert_value store ~tx:(Some tx) (Sn.of_int 0) failing_value
+                    >>= fun _ -> Lwt.return 0)
+         (fun _ -> Lwt.return 1)) >>= fun r ->
+      if r = 0
+      then failwith "safe_insert_value did not fail while in a transaction"
+      else Lwt.return ()))
+
+
+let suite =
+  let w f = lwt_bracket setup f teardown in
+  "store" >:::[
+    "safe_insert_value" >:: w test_safe_insert_value;
+    "safe_insert_value_with_tx" >:: w test_safe_insert_value_with_tx;
+  ]
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/system/startup.ml
+++ b/src/system/startup.ml
@@ -73,7 +73,7 @@ let _make_tlog_coll tlcs values tlc_name use_compression node_id =
 
 let _make_store ?(read_only=false) stores now node_name (db_name:string) =
   Mem_store.make_mem_store db_name >>= fun store ->
-  store # set_master node_name now >>= fun () -> 
+  store # with_transaction (fun tx -> store # set_master tx node_name now) >>= fun () -> 
   Hashtbl.add stores db_name store;
   Lwt.return store
 


### PR DESCRIPTION
Contrary to it's name this branch contains the following changes:
- added sub i tracking (represented by the 'j' counter) to the store, to ensure transactional application of paxos values (with multiple updates) to the store, should the node die while applying these updates
- added with_transaction to the store. the supplied transaction object is as off now required to perform updates to the store.
- added a mechanism (with_transaction_lock) to lock the aquirement of a transaction to help in ensuring the application of a paxos value to the store happens transactionally
- batched multiple tlog entries into 1 store-transaction when performing catchup
- tests for all of the above

suggestions, especially related to my transaction_lock thingie are appreciated.

Other possible changes:
- make batch size configurable
- add batching for the updates inside 1 paxos value (in regular non catchup regime)

I still need to run the integration tests, will do this as soon as the infrastructure for this is completely working again. This also needs a ticket, will provide the issue number here once it has been created.
