### PR TITLE
Pylabs: Return exit code of 'start', 'restart' and 'catchupOnly' invocations

### DIFF
--- a/extension/server/ArakoonManagement.py
+++ b/extension/server/ArakoonManagement.py
@@ -869,7 +869,7 @@ class ArakoonCluster:
 
         """
         self._requireLocal(nodeName)
-        self._startOne(nodeName)
+        return self._startOne(nodeName)
 
     
     def catchupOnly(self, nodeName):
@@ -885,7 +885,7 @@ class ArakoonCluster:
                '--node',
                nodeName,
                '-catchup-only']
-        subprocess.call(cmd)
+        return subprocess.call(cmd)
         
     def stopOne(self, nodeName):
         """
@@ -973,7 +973,7 @@ class ArakoonCluster:
 
         """
         self._requireLocal( nodeName)
-        self._restartOne(nodeName)
+        return self._restartOne(nodeName)
 
     def getStatusOne(self, nodeName):
         """
@@ -1022,7 +1022,7 @@ class ArakoonCluster:
         command = self._cmd(name)
         cmd.extend(command)
         logging.debug('calling: %s', str(cmd))
-        subprocess.call(cmd, close_fds = True)
+        return subprocess.call(cmd, close_fds = True)
 
     def _getIp(self,ip_mess):
         t_mess = type(ip_mess)
@@ -1069,7 +1069,7 @@ class ArakoonCluster:
     
     def _restartOne(self, name):
         self._stopOne(name)
-        self._startOne(name)
+        return self._startOne(name)
 
 
     def _getPid(self, name):

--- a/extension/test/server/quick/system_tests_basic.py
+++ b/extension/test/server/quick/system_tests_basic.py
@@ -68,6 +68,19 @@ def test_start_stop_wrapper():
     C.assert_running_nodes(0)
     cluster.tearDown()
 
+def test_start_arakoon383():
+    cluster = C._getCluster()
+    wrapper = 'false'
+    name = 'wrapper'
+    cluster.addNode(name, '127.0.0.1', 8000, wrapper=wrapper)
+    cluster.addLocalNode(name)
+    C.assert_running_nodes(0)
+    assert_equals(cluster.startOne(name), 1)
+    C.assert_running_nodes(0)
+    assert_equals(cluster.restartOne(name), 1)
+    C.assert_running_nodes(0)
+    cluster.tearDown()
+
 @C.with_custom_setup(C.setup_1_node, C.basic_teardown)
 def test_max_value_size_tinkering ():
     cluster = C._getCluster()


### PR DESCRIPTION
See: ARAKOON-383
See: http://jira.incubaid.com/browse/ARAKOON-383
See: ARAKOON-379
See: http://jira.incubaid.com/browse/ARAKOON-379
