### PR TITLE
close the tlc after catchup_only

### DIFF
--- a/extension/test/server/left/system_tests_long_left.py
+++ b/extension/test/server/left/system_tests_long_left.py
@@ -153,3 +153,5 @@ def test_catchup_only():
     logging.info("done with catchup-only")
     C.stopOne(n0)
     C.compare_stores(n1,n0)
+    C.start_all()
+    C.assert_running_nodes(2)

--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -198,7 +198,9 @@ let only_catchup ~name ~cluster_cfg ~make_store ~make_tlog_coll =
   let future_n = Sn.start in
   let future_i = Sn.start in
   Catchup.catchup me other_configs ~cluster_id 
-    (store,tlc)  current_i mr_name (future_n,future_i) 
+    (store,tlc)  current_i mr_name (future_n,future_i) >>= fun _ ->
+  tlc # close () 
+  
     
     
 module X = struct 
@@ -317,6 +319,7 @@ let _main_2
     begin
       only_catchup ~name ~cluster_cfg ~make_store ~make_tlog_coll 
       >>= fun _ -> (* we don't need that here as there is no continuation *)
+      
       Lwt.return 0
     end
   else


### PR DESCRIPTION
ARAKOON-382:Arakoon fails to start when doing a catchup only before starting
