### PR TITLE
Optimize logging

### DIFF
--- a/_tags
+++ b/_tags
@@ -8,6 +8,7 @@ true: package(bz2)
 true: package(str)
 true: package(camltc)
 true: package(dynlink)
+true: pp(camlp4of)
 "doc": include
 "src":include
 "src/tools":include
@@ -16,7 +17,6 @@ true: package(dynlink)
 "src/msg":include
 "src/paxos": include
 "src/tlog": include
-"src/tlog/tlogcommon.ml": use_macro
 "src/node": include
 "src/system": include
 "src/inifiles": include
@@ -32,3 +32,5 @@ true: package(dynlink)
 <examples/ocaml/*.{byte,native}>: is_main
 <src/arakoon_client.*{cma,cmxa}>: use_thread
 <src/plugins/*.{cma,cmxa}>: use_thread
+"logger_macro.cmo" : use_camlp4, camlp4orf
+<src/**/*.ml> : camlp4of, use_log_macro

--- a/logger_macro.ml
+++ b/logger_macro.ml
@@ -1,0 +1,198 @@
+open Camlp4.PreCast
+
+(*
+
+This file defines several macros related to the Logger module.
+
+It is important to keep in mind that macros can't always be used like functions, therefor it's useful to know how these macros are expanded.
+
+The general structure is the following (in which level can be any of Debug|Info|Notice|Warning|Error|Fatal):
+Logger.level    ?exn section msg
+Logger.level_   ?exn msg
+Logger.level_f  ?exn section format_string and args
+Logger.level_f_ ?exn format_string and args
+
+The macros ending with _ grab a variable named section from the enviroment.
+Macros containing _f wrap the 'format_string and args' part into a closure which can at a later time be evaluated to calculate a string.
+
+Some concrete examples:
+
+Logger.debug section "log this"
+=> Logger.log section Logger.Debug "log this"
+
+Logger.debug_ "log this"
+=> Logger.log section Logger.Debug "log this"
+
+Logger.debug_f section "format%s string" "bla"
+=> Logger.log_ section Logger.Debug (fun () -> Printf.sprintf "format%s string" "bla")
+
+Logger.debug_f_ "format%s string" "bla"
+=> Logger.log_ section Logger.Debug (fun () -> Printf.sprintf "format%s string" "bla")
+
+*)
+
+let rec apply e = function
+  | [] -> e
+  | x :: l -> let _loc = Ast.loc_of_expr x in apply <:expr< $e$ $x$ >> l
+
+let split e =
+  let rec aux acc = function
+    | <:expr@_loc< Logger.log_f $section$ $level$ >> ->
+        `Log_f(section, level, acc)
+    | <:expr@_loc< Logger.$lid:func$ ~exn $arg$ >> ->
+        let implicit_section = func.[String.length func - 1] = '_' in
+        let pos = String.length func - 1 - (if implicit_section then 1 else 0) in
+        let is_f = func.[pos] = 'f' in
+        if not is_f
+        then
+          let level = String.sub func 0 (pos + 1) in
+          if level = "log"
+          then
+            `No_match
+          else
+            let level' = String.capitalize level in
+            if implicit_section
+            then
+              `Log_e_l_ (arg::acc, level')
+            else
+              `Log_e_l(acc, level', arg)
+        else
+          let level = String.sub func 0 (pos - 1) in
+          let level' = String.capitalize level in
+          if implicit_section
+          then
+            `Log_e_f_l_ (arg::acc, level')
+          else
+            `Log_e_f_l (acc, level', arg)
+    | <:expr@_loc< Logger.$lid:func$ $arg$ >> ->
+        let implicit_section = func.[String.length func - 1] = '_' in
+        let pos = String.length func - 1 - (if implicit_section then 1 else 0) in
+        let is_f = func.[pos] = 'f' in
+        if not is_f
+        then
+          let level = String.sub func 0 (pos + 1) in
+          if level = "log"
+          then
+            `No_match
+          else
+            let level' = String.capitalize level in
+            if implicit_section
+            then
+              `Log_l_(arg::acc, level')
+            else
+              `Log_l (acc, level', arg)
+        else
+          let level = String.sub func 0 (pos - 1) in
+          let level' = String.capitalize level in
+          if implicit_section
+          then
+            `Log_f_l_ (arg::acc, level')
+          else
+            `Log_f_l (acc, level', arg)
+    | <:expr@loc< $a$ $b$ >> -> begin
+        match b with
+          | b ->
+              aux (b :: acc) a
+      end
+    | _ ->
+        `No_match
+  in
+  aux [] e
+
+let make_loc _loc =
+  <:expr<
+    ($str:Loc.file_name _loc$,
+     $int:string_of_int (Loc.start_line _loc)$,
+     $int:string_of_int (Loc.start_off _loc - Loc.start_bol _loc)$)
+  >>
+
+let map =
+object
+  inherit Ast.map as super
+
+  method expr e =
+    let _loc = Ast.loc_of_expr e in
+    match split e with
+      | `Log_f(section, level, args) ->
+          let args = List.map super#expr args in
+          <:expr<
+            Logger.log_
+            $section$
+            $level$
+            (fun () -> $apply <:expr< Printf.sprintf >> args$)
+          >>
+      | `Log_l_(args, level) ->
+          let args = List.map super#expr args in
+          apply
+          <:expr<
+            Logger.log
+            section
+            Lwt_log.$uid:level$
+          >> args
+      | `Log_e_l_(args, level) ->
+          let args = List.map super#expr args in
+          apply
+          <:expr<
+            Logger.log
+            ~exn
+            section
+            Lwt_log.$uid:level$
+          >> args
+      | `Log_l(args, level, section) ->
+          let args = List.map super#expr args in
+          apply
+          <:expr<
+            Logger.log
+            $section$
+            Lwt_log.$uid:level$
+          >> args
+      | `Log_e_l(args, level, section) ->
+          let args = List.map super#expr args in
+          apply <:expr<
+            Logger.log
+            ~exn
+            $section$
+            Lwt_log.$uid:level$
+          >> args
+      | `Log_f_l_(args, level) ->
+          let args = List.map super#expr args in
+            <:expr<
+              Logger.log_
+              section
+              Lwt_log.$uid:level$
+              (fun () -> $apply <:expr< Printf.sprintf >> args$)
+            >>
+      | `Log_e_f_l_(args, level) ->
+          let args = List.map super#expr args in
+            <:expr<
+              Logger.log_
+              ~exn
+              section
+              Lwt_log.$uid:level$
+              (fun () -> $apply <:expr< Printf.sprintf >> args$)
+            >>
+      | `Log_f_l(args, level, section) ->
+          let args = List.map super#expr args in
+          <:expr<
+            Logger.log_
+            $section$
+            Lwt_log.$uid:level$
+            (fun () -> $apply <:expr< Printf.sprintf >> args$)
+          >>
+      | `Log_e_f_l(args, level, section) ->
+          let args = List.map super#expr args in
+          <:expr<
+            Logger.log_
+            ~exn
+            $section$
+            Lwt_log.$uid:level$
+            (fun () -> $apply <:expr< Printf.sprintf >> args$)
+          >>
+      | `No_match ->
+          super#expr e
+end
+
+let () =
+  AstFilters.register_str_item_filter map#str_item;
+  AstFilters.register_topphrase_filter map#str_item;
+

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -201,7 +201,9 @@ let _ = dispatch & function
 
     flag ["link";"use_bisect"] (S[A"-ccopt";A"--coverage";]);
 
-    flag ["pp";"ocaml";"use_macro"] (S[A"camlp4of";A"pa_macro.cmo"]);
+    flag ["pp";"ocaml";"use_log_macro"] (A"logger_macro.cmo");
+    dep ["ocaml"; "ocamldep"; "use_log_macro"] ["logger_macro.cmo"];
+
     flag ["pp";"ocaml";"use_bisect"]
       (S[A"-no_quot";A(path_to_bisect_instrument()  ^ "/instrument.cmo")]);
     

--- a/src/all_test.ml
+++ b/src/all_test.ml
@@ -30,7 +30,7 @@ let configure_logging () =
     ()
   in
   Lwt_log.default := logger;
-  Lwt_log.Section.set_level Lwt_log.Section.main Lwt_log.Debug
+  Logger.Section.set_level Logger.Section.main Logger.Debug
 
 let tools_tests = "tools" >::: [
   Server_test.suite;

--- a/src/msg/tcp_messaging_test.ml
+++ b/src/msg/tcp_messaging_test.ml
@@ -34,7 +34,7 @@ object(self)
   val mutable _lowest = None
 
   method _send target msg =
-    Lwt_log.debug_f "%s sending message %s to %s" 
+    Logger.debug_f_ "%s sending message %s to %s" 
       id (string_of msg) target >>= fun () ->
     m # send_message msg id target 
       
@@ -51,7 +51,7 @@ object(self)
   method wait_for_response n  targets=
     m # recv_message id >>= fun (msg, source) ->
     let n' = int_of_string ( msg.payload ) in 
-    Lwt_log.debug_f "n=%d n'=%d" n n' >>= fun () -> 
+    Logger.debug_f_ "n=%d n'=%d" n n' >>= fun () -> 
     if n' == n  
     then
       begin
@@ -126,12 +126,12 @@ let test_pingpong_1x1 () =
     Lwt.pick [ transport # run ~setup_callback ~teardown_callback (); 
 	       begin 
 		 Lwt_condition.wait cvar >>= fun () ->
-		 Lwt_log.debug "going to serve" >>= fun () ->
+		 Logger.debug_ "going to serve" >>= fun () ->
 			     player_a # serve "a"
 	       end;
 	       eventually_die ()
 	     ] >>= fun () -> Lwt_mvar.take td >>= fun () ->
-    Lwt_log.info "end of scenario"
+    Logger.info_ "end of scenario"
   in
   Lwt_main.run (main_t());;
     
@@ -163,7 +163,7 @@ let test_pingpong_2x2 () =
 	     ] >>= fun () ->
     Lwt_mvar.take m_tda >>= fun () ->
     Lwt_mvar.take m_tdb >>= fun () ->
-    Lwt_log.info "end of scenario"
+    Logger.info_ "end of scenario"
   in
   Lwt_main.run (main_t())
     
@@ -208,7 +208,7 @@ let test_pingpong_multi_server () =
     Lwt_mvar.take m_tda >>= fun () ->
     Lwt_mvar.take m_tdb >>= fun () ->
     Lwt_mvar.take m_tdc >>= fun () ->
-    Lwt_log.info "end of scenario"
+    Logger.info_ "end of scenario"
   in
   Lwt_main.run (main_t());;
 
@@ -232,17 +232,17 @@ let test_pingpong_restart () =
     Lwt.pick [ 
       begin 
 	Lwt.pick [ t_a # run ();
-		   player_a # run 50 () >>= fun () -> Lwt_log.debug "a done" 
+		   player_a # run 50 () >>= fun () -> Logger.debug_ "a done" 
 		 ]
 	>>= fun () ->
 	let t_a' = make_transport address_a in
 	let () = t_a' # register_receivers mapping in
 	let player_a' = new player "a" t_a' in
 	Lwt.pick [
-	  (Lwt_log.info "new network" >>= fun () -> 
+	  (Logger.info_ "new network" >>= fun () -> 
 	   t_a' # run ()); 
 	  begin 
-	    Lwt_log.debug "a' will be serving momentarily" >>= fun () ->
+	    Logger.debug_ "a' will be serving momentarily" >>= fun () ->
 	    player_a' # serve ~n:200 "b" 
 	  end
 	]
@@ -251,7 +251,7 @@ let test_pingpong_restart () =
       player_a # serve "b";
       player_b # run 0 ();
       eventually_die () ]
-    >>= fun () -> Lwt_log.info "main_t: after pick"
+    >>= fun () -> Logger.info_ "main_t: after pick"
   in
   Lwt_main.run main_t
 

--- a/src/node/collapser_main.ml
+++ b/src/node/collapser_main.ml
@@ -39,7 +39,7 @@ let collapse_remote ip port cluster_id n =
     in
     Lwt.catch
       (fun () -> Lwt_io.with_connection address collapse)
-      (fun exn -> Lwt_log.fatal ~exn "remote_collapsing_failed" 
+      (fun exn -> Logger.fatal Logger.Section.main ~exn "remote_collapsing_failed" 
 	>>= fun () -> Lwt.return (-1)
       )
   in

--- a/src/node/mem_store.ml
+++ b/src/node/mem_store.ml
@@ -109,7 +109,7 @@ let copy_store2 old_location new_location overwrite = Lwt.return ()
 let relocate new_location = failwith "Memstore.relocation not implemented"
 
 let get_fringe ms boundary direction =
-    Lwt_log.debug_f "mem_store :: get_border_range %s" (Log_extra.string_option2s boundary) >>= fun () ->
+    Logger.debug_f_ "mem_store :: get_border_range %s" (Log_extra.string_option2s boundary) >>= fun () ->
     let cmp =
       begin
         match direction, boundary with

--- a/src/node/node_cfg.ml
+++ b/src/node/node_cfg.ml
@@ -20,6 +20,7 @@ GNU Affero General Public License along with this program (file "COPYING").
 If not, see <http://www.gnu.org/licenses/>.
 *)
 
+let section = Logger.Section.main
 
 let config_file = ref "cfg/arakoon.ini"
 
@@ -387,7 +388,7 @@ module Node_cfg = struct
 
   open Lwt
   let validate_dirs t = 
-    Lwt_log.debug "Node_cfg.validate_dirs" >>= fun () ->
+    Logger.debug_ "Node_cfg.validate_dirs" >>= fun () ->
     if t.is_test then Lwt.return ()
     else
       begin
@@ -398,14 +399,14 @@ module Node_cfg = struct
 	in
         if not (is_ok t.home)
         then
-          Lwt_log.fatal_f
+          Logger.fatal_f_
             "Home dir '%s' doesn't exist, or insufficient permissions"
             t.home >>= fun () ->
           Lwt.fail (InvalidHomeDir t.home)
         else
         if not (is_ok t.tlog_dir)
         then
-          Lwt_log.fatal_f
+          Logger.fatal_f_
             "Tlog dir '%s' doesn't exist, or insufficient permissions"
             t.tlog_dir >>= fun () ->
           Lwt.fail (InvalidTlogDir t.tlog_dir)

--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -31,6 +31,8 @@ open Master_type
 open Client_cfg
 open Statistics
 
+let section = Logger.Section.main
+
 let rec _split node_name cfgs =
   let rec loop me_o others = function
     | [] -> me_o, others
@@ -63,20 +65,20 @@ let _config_logging me get_cfgs =
             failwith ("Could not find log section " ^ log_config' ^ " for node " ^ me)
   in
   let to_level = function
-      | "info"    -> Lwt_log.Info
-      | "notice"  -> Lwt_log.Notice
-      | "warning" -> Lwt_log.Warning
-      | "error"   -> Lwt_log.Error
-      | "fatal"   -> Lwt_log.Fatal
-      | _         -> Lwt_log.Debug
+      | "info"    -> Logger.Info
+      | "notice"  -> Logger.Notice
+      | "warning" -> Logger.Warning
+      | "error"   -> Logger.Error
+      | "fatal"   -> Logger.Fatal
+      | _         -> Logger.Debug
   in
   let level = to_level cfg.log_level in
-  let () = Lwt_log.Section.set_level Lwt_log.Section.main level in
+  let () = Logger.Section.set_level Logger.Section.main level in
   let set_level section l =
     let l = match l with
       | None -> level
       | Some l -> to_level l in
-    Lwt_log.Section.set_level section l in
+    Logger.Section.set_level section l in
   let () = set_level Client_protocol.section log_config.client_protocol in
   let () = set_level Multi_paxos.section log_config.paxos in
   let () = set_level Tcp_messaging.section log_config.tcp_messaging in
@@ -146,7 +148,7 @@ let _config_service cfg backend=
   uber_service
     
 let _log_rotate cfg i get_cfgs =
-  Lwt_log.warning_f "received USR1 (%i) going to close/reopen log file" i
+  Logger.warning_f_ "received USR1 (%i) going to close/reopen log file" i
   >>= fun () ->
   let logger = !Lwt_log.default in
   _config_logging cfg get_cfgs >>= fun _ ->
@@ -154,25 +156,25 @@ let _log_rotate cfg i get_cfgs =
   Lwt.return ()
     
 let log_prelude cluster_cfg =
-  Lwt_log.info "--- NODE STARTED ---" >>= fun () ->
-  Lwt_log.info_f "git_revision: %s " Version.git_revision >>= fun () ->
-  Lwt_log.info_f "compile_time: %s " Version.compile_time >>= fun () ->
-  Lwt_log.info_f "version: %i.%i.%i" Version.major Version.minor Version.patch   >>= fun () ->
-  Lwt_log.info_f "NOFILE: %i" (Limits.get_rlimit Limits.NOFILE Limits.Soft)      >>= fun () ->
-  Lwt_log.info_f "tlogEntriesPerFile: %i" (!Tlogcommon.tlogEntriesPerFile)       >>= fun () ->
-  Lwt_log.info_f "max_value_size: %i" cluster_cfg.max_value_size                 >>= fun () ->
-  Lwt_log.info_f "max_buffer_size: %i" cluster_cfg.max_buffer_size               >>= fun () ->
-  Lwt_log.info_f "client_buffer_capacity: %i" cluster_cfg.client_buffer_capacity >>= fun () -> 
+  Logger.info_ "--- NODE STARTED ---" >>= fun () ->
+  Logger.info_f_ "git_revision: %s " Version.git_revision >>= fun () ->
+  Logger.info_f_ "compile_time: %s " Version.compile_time >>= fun () ->
+  Logger.info_f_ "version: %i.%i.%i" Version.major Version.minor Version.patch   >>= fun () ->
+  Logger.info_f_ "NOFILE: %i" (Limits.get_rlimit Limits.NOFILE Limits.Soft)      >>= fun () ->
+  Logger.info_f_ "tlogEntriesPerFile: %i" (!Tlogcommon.tlogEntriesPerFile)       >>= fun () ->
+  Logger.info_f_ "max_value_size: %i" cluster_cfg.max_value_size                 >>= fun () ->
+  Logger.info_f_ "max_buffer_size: %i" cluster_cfg.max_buffer_size               >>= fun () ->
+  Logger.info_f_ "client_buffer_capacity: %i" cluster_cfg.client_buffer_capacity >>= fun () -> 
   let ncfgo = cluster_cfg.nursery_cfg in
   let p2s (nc,cfg) =  Printf.sprintf "(%s,%s)" nc (ClientCfg.to_string cfg) in
   let ccfg_s = Log_extra.option2s p2s ncfgo in
-  Lwt_log.info_f "client_cfg=%s" ccfg_s
+  Logger.info_f_ "client_cfg=%s" ccfg_s
     
 
 let full_db_name me = me.home ^ "/" ^ me.node_name ^ ".db" 
 
 let only_catchup (type s) (module S : Store.STORE with type t = s) ~name ~cluster_cfg ~make_tlog_coll = 
-  Lwt_log.info "ONLY CATCHUP" >>= fun () ->
+  Logger.info_ "ONLY CATCHUP" >>= fun () ->
   let node_cnt = List.length cluster_cfg.cfgs in
   let me, other_configs = _split name cluster_cfg.cfgs in
   let cluster_id = cluster_cfg.cluster_id in
@@ -222,7 +224,7 @@ module X = struct
 	    S.on_consensus store vni >>= fun r ->
         let t1 = Unix.gettimeofday () in
         let d = t1 -. t0 in
-        Lwt_log.debug_f "T:on_consensus took: %f" d  >>= fun () ->
+        Logger.debug_f_ "T:on_consensus took: %f" d  >>= fun () ->
         Lwt.return r
 
     end
@@ -231,7 +233,7 @@ module X = struct
     
   let on_accept (type s) statistics (tlog_coll:Tlogcollection.tlog_collection) (module S : Store.STORE with type t = s) store (v,n,i) =
     let t0 = Unix.gettimeofday () in
-    Lwt_log.debug_f "on_accept: n:%s i:%s" (Sn.string_of n) (Sn.string_of i) 
+    Logger.debug_f_ "on_accept: n:%s i:%s" (Sn.string_of n) (Sn.string_of i) 
     >>= fun () ->
     let sync = Value.is_synced v in
     let marker = (None:string option) in
@@ -259,7 +261,7 @@ module X = struct
                   if (Int64.sub now !last_master_log_stmt >= 60L)  or new_master then
                     begin
                       last_master_log_stmt := now;
-                      Lwt_log.info_f "%s is master"  m
+                      Logger.info_f_ "%s is master"  m
                     end 
                   else 
                     Lwt.return ()
@@ -270,14 +272,14 @@ module X = struct
     end  >>= fun () ->
     let t1 = Unix.gettimeofday() in
     let d = t1 -. t0 in
-    Lwt_log.debug_f "T:on_accept took: %f" d 
+    Logger.debug_f_ "T:on_accept took: %f" d 
       
   let reporting period backend () = 
     let fp = float period in
     let rec _inner () =
       Lwt_unix.sleep fp >>= fun () ->
       let stats = backend # get_statistics () in
-      Lwt_log.info_f "stats: %s" (Statistics.string_of stats) 
+      Logger.info_f_ "stats: %s" (Statistics.string_of stats) 
       >>= fun () ->
       backend # clear_most_statistics();
       _inner ()
@@ -354,7 +356,7 @@ let _main_2 (type s)
       let rec upload_cfg_to_keeper () =
         begin
           match cluster_cfg.nursery_cfg with
-            | None -> Lwt_log.info "Cluster not part of nursery."
+            | None -> Logger.info_ "Cluster not part of nursery."
             | Some (n_cluster_id, cfg) ->
               begin 
                 let attempt_send success node_id = 
@@ -364,7 +366,7 @@ let _main_2 (type s)
                       begin
                         let (ips, port) = ClientCfg.get cfg node_id in
                         let ipss = Log_extra.list2s (fun s -> s) ips in
-                        Lwt_log.debug_f "upload_cfg_to_keeper (%s,%i)" ipss port >>= fun () ->
+                        Logger.debug_f_ "upload_cfg_to_keeper (%s,%i)" ipss port >>= fun () ->
                         Lwt.catch
                           (fun () ->
                             let ip0 = List.hd ips in
@@ -374,12 +376,12 @@ let _main_2 (type s)
                               client # store_cluster_cfg cluster_id my_clicfg
                             in 
                             Lwt_io.with_connection address upload >>= fun () ->
-                            Lwt_log.info_f "Successfully uploaded config to nursery node %s" node_id >>= fun () ->
+                            Logger.info_f_ "Successfully uploaded config to nursery node %s" node_id >>= fun () ->
                             Lwt.return true
                           ) 
                           (fun e ->
                             let exc_msg = Printexc.to_string e in
-                            Lwt_log.warning_f "Attempt to upload config to %s failed (%s)" node_id exc_msg 
+                            Logger.warning_f_ "Attempt to upload config to %s failed (%s)" node_id exc_msg 
                             >>= fun () -> 
                             Lwt.return false
                           )
@@ -398,12 +400,12 @@ let _main_2 (type s)
       in
       Lwt.ignore_result ( upload_cfg_to_keeper () ) ;
       let messaging  = _config_messaging me cfgs cookie me.is_laggy (float me.lease_period) cluster_cfg.max_buffer_size in
-      Lwt_log.info_f "cfg = %s" (string_of me) >>= fun () ->
-      Lwt_list.iter_s (Lwt_log.info_f "other: %s")
+      Logger.info_f_ "cfg = %s" (string_of me) >>= fun () ->
+      Lwt_list.iter_s (fun m -> Logger.info_f_ "other: %s" m)
 	    other_names >>= fun () ->
-      Lwt_log.info_f "quorum_function gives %i for %i" 
+      Logger.info_f_ "quorum_function gives %i for %i" 
 	    (quorum_function n_nodes) n_nodes >>= fun () ->
-      Lwt_log.info_f "DAEMONIZATION=%b" daemonize >>= fun () ->
+      Logger.info_f_ "DAEMONIZATION=%b" daemonize >>= fun () ->
       
       let build_startup_state () = 
 	    begin
@@ -444,21 +446,21 @@ let _main_2 (type s)
                   end 
                 in
                 begin
-                  Lwt_log.debug_f "store_i: '%s' tlog_i: '%s' Diff: %d" 
+                  Logger.debug_f_ "store_i: '%s' tlog_i: '%s' Diff: %d" 
 		            (Sn.string_of s_i) 
 		            (Sn.string_of tlog_i)  
 		            (Sn.compare s_i tlog_i)  >>= fun() ->
                   if (Sn.compare s_i tlog_i)  <= 0
                   then
 		            begin
-                      Lwt_log.warning_f "Invalid tlog file found. Auto-truncating tlog %s" 
+                      Logger.warning_f_ "Invalid tlog file found. Auto-truncating tlog %s" 
 			            last_tlog >>= fun () ->
                       let _ = Tlc2.truncate_tlog last_tlog in
                       make_tlog_coll me.tlog_dir me.use_compression name
 		            end
                   else 
 		            begin
-                      Lwt_log.error_f "Store counter (%s) ahead of tlogs (%s). Aborting" 
+                      Logger.error_f_ "Store counter (%s) ahead of tlogs (%s). Aborting" 
 			            (Sn.string_of s_i) (Sn.string_of tlog_i) >>= fun () ->
                       Lwt.fail(Catchup.StoreAheadOfTlogs(pos,tlog_i))
 		            end
@@ -518,7 +520,7 @@ let _main_2 (type s)
 		        | Multi_paxos.ElectionTimeout _ -> election_timeout_buffer, "election"
 		        | _ -> inject_buffer, "inject"
 	        in
-	        Lwt_log.debug_f ~section:Multi_paxos.section "XXX injecting event %s into '%s'" 
+	        Logger.debug_f Multi_paxos.section "XXX injecting event %s into '%s'" 
               (Multi_paxos.paxos_event2s e)
               name 
             >>= fun () ->
@@ -595,10 +597,10 @@ let _main_2 (type s)
 			            rapporting ();
                         (listen_for_signal () >>= fun () ->
                          let msg = "got TERM | INT" in
-			             Lwt_log.info msg >>= fun () ->
+			             Logger.info_ msg >>= fun () ->
 			             Lwt_io.printl msg >>= fun () ->
                          S.close store >>= fun () ->
-                         Lwt_log.fatal_f 
+                         Logger.fatal_f_
                            ">>> Closing the store @ %S succeeded: everything seems OK <<<"
                            (S.get_location store)
                          >>= fun () ->
@@ -609,39 +611,39 @@ let _main_2 (type s)
 		              ]
 	        end
 	      ] >>= fun () ->
-          Lwt_log.info "Completed shutdown" 
+          Logger.info_ "Completed shutdown" 
           >>= fun () ->
           Lwt.return 0
         )
 	    (function
           | Catchup.StoreAheadOfTlogs(s_i, tlog_i) ->
               let rc = 40 in
-              Lwt_log.fatal_f "[rc=%i] Store ahead of tlogs: s_i=%s, tlog_i=%s"
+              Logger.fatal_f_ "[rc=%i] Store ahead of tlogs: s_i=%s, tlog_i=%s"
                 rc (Sn.string_of s_i) (Sn.string_of tlog_i) >>= fun () ->
               Lwt.return rc
           | Catchup.StoreCounterTooLow msg ->
               let rc = 41 in
-              Lwt_log.fatal_f "[rc=%i] Store counter too low: %s" rc msg >>= fun () ->
+              Logger.fatal_f_ "[rc=%i] Store counter too low: %s" rc msg >>= fun () ->
               Lwt.return rc
           | Tlc2.TLCNotProperlyClosed msg -> 
               let rc = 42 in
-              Lwt_log.fatal_f "[rc=%i] tlog not properly closed %s" rc msg >>= fun () ->
+              Logger.fatal_f_ "[rc=%i] tlog not properly closed %s" rc msg >>= fun () ->
               Lwt.return rc
           | Node_cfg.InvalidTlogDir dir ->
               let rc = 43 in
-              Lwt_log.fatal_f "[rc=%i] Missing or inaccessible tlog directory: %s" rc dir >>= fun () ->
+              Logger.fatal_f_ "[rc=%i] Missing or inaccessible tlog directory: %s" rc dir >>= fun () ->
               Lwt.return rc
           | Node_cfg.InvalidHomeDir dir ->
               let rc = 44 in
-              Lwt_log.fatal_f "[rc=%i] Missing or inaccessible home directory: %s" rc dir >>= fun () ->
+              Logger.fatal_f_ "[rc=%i] Missing or inaccessible home directory: %s" rc dir >>= fun () ->
               Lwt.return rc
           | exn -> 
               begin
-	            Lwt_log.fatal ~exn "going down" >>= fun () ->
-	            Lwt_log.fatal "after pick" >>= fun() ->
+	            Logger.fatal_ ~exn "going down" >>= fun () ->
+	            Logger.fatal_ "after pick" >>= fun() ->
 	            begin
                   match dump_crash_log with
-	                | None -> Lwt_log.info "Not dumping state"
+	                | None -> Logger.info_ "Not dumping state"
 	                | Some f -> f() 
                 end >>= fun () ->
                 Lwt.return 1

--- a/src/node/store_test.ml
+++ b/src/node/store_test.ml
@@ -25,22 +25,24 @@ open Lwt
 open Extra
 open Update
 
+let section = Logger.Section.main
+
 module S = (val (Store.make_store_module (module Local_store)))
 
 let _dir_name = "/tmp/store_test"
 
 let setup () = 
-  Lwt_log.info "Store_test.setup" >>= fun () ->
+  Logger.info_ "Store_test.setup" >>= fun () ->
   let ignore_ex f = 
     Lwt.catch 
       f
-      (fun exn -> Lwt_log.warning ~exn "ignoring")
+      (fun exn -> Logger.warning_ ~exn "ignoring")
   in
   ignore_ex (fun () -> File_system.rmdir _dir_name) >>= fun () ->
   ignore_ex (fun () -> File_system.mkdir  _dir_name 0o750 )
 
 let teardown () = 
-  Lwt_log.info "Store_test.teardown" >>= fun () ->
+  Logger.info_ "Store_test.teardown" >>= fun () ->
   Lwt.catch
     (fun () ->
       File_system.lwt_directory_list _dir_name >>= fun entries ->
@@ -48,9 +50,9 @@ let teardown () =
 	let fn = _dir_name ^ "/" ^ i in
         Lwt_unix.unlink fn) entries 
     )
-    (fun exn -> Lwt_log.debug ~exn "ignoring" )
+    (fun exn -> Logger.debug_ ~exn "ignoring" )
     >>= fun () ->
-  Lwt_log.debug "end of teardown"
+  Logger.debug_ "end of teardown"
 
 let with_store name f =
   let db_name = _dir_name ^ "/" ^ name ^ ".db" in
@@ -95,7 +97,7 @@ let test_safe_insert_value () =
           (fun assert' -> assert' store)
           asserts)
       value_asserts in
-  Lwt_log.info "applying updates without surrounding transaction" >>= fun () ->
+  Logger.info_ "applying updates without surrounding transaction" >>= fun () ->
   with_store "tsiv" (fun store ->
     do_asserts store)
 

--- a/src/node/test_backend.ml
+++ b/src/node/test_backend.ml
@@ -21,7 +21,6 @@ If not, see <http://www.gnu.org/licenses/>.
 *)
 
 open Lwt
-open Lwt_log
 open Backend
 open Statistics
 open Update
@@ -29,8 +28,9 @@ open Routing
 open Common
 open Interval
 
-module StringMap = Map.Make(String);;
+let section = Logger.Section.main
 
+module StringMap = Map.Make(String);;
 
 let one_ f first finc last linc max (k:string) (v:string) acc =
   let count = fst acc and a = snd acc in
@@ -115,7 +115,7 @@ class test_backend my_name = object(self:#backend)
     else self # set key value
 
   method aSSert ~allow_dirty (key:string) (vo: string option) =
-    Lwt_log.debug_f "test_backend :: aSSert %s" key >>= fun () ->
+    Logger.debug_f_ "test_backend :: aSSert %s" key >>= fun () ->
     let ok = match vo with
       | None -> StringMap.mem key _kv = false
       | Some v -> StringMap.find key _kv = v
@@ -128,7 +128,7 @@ class test_backend my_name = object(self:#backend)
     else Lwt.return ()
 
   method aSSert_exists ~allow_dirty (key:string)=
-    Lwt_log.debug_f "test_backend :: aSSert_exists %s" key >>= fun () ->
+    Logger.debug_f_ "test_backend :: aSSert_exists %s" key >>= fun () ->
     let ok =
       StringMap.mem key _kv
     in
@@ -192,19 +192,19 @@ class test_backend my_name = object(self:#backend)
   method range_entries ~allow_dirty (first:string option) (finc:bool)
     (last:string option) (linc:bool) (max:int) =
     let x = range_entries_ _kv first finc last linc max in
-    info_f "range_entries: found %d entries" (List.length x) >>= fun () ->
+    Logger.info_f_ "range_entries: found %d entries" (List.length x) >>= fun () ->
     Lwt.return x
 
   method rev_range_entries ~allow_dirty (first:string option) (finc:bool)
     (last:string option) (linc:bool) (max:int) =
     let x = rev_range_entries_ _kv first finc last linc max in
-    info_f "rev_range_entries: found %d entries" (List.length x) >>= fun () ->
+    Logger.info_f_ "rev_range_entries: found %d entries" (List.length x) >>= fun () ->
     Lwt.return x
 
   method range ~allow_dirty (first:string option) (finc:bool)
     (last:string option) (linc:bool) (max:int) =
     let x = range_ _kv first finc last linc max in
-    info_f "range: found %d entries" (List.length x) >>= fun () ->
+    Logger.info_f_ "range: found %d entries" (List.length x) >>= fun () ->
     Lwt.return x
 
   method prefix_keys ~allow_dirty (prefix:string) (max:int) =
@@ -220,7 +220,7 @@ class test_backend my_name = object(self:#backend)
   method who_master () = Lwt.return (Some my_name)
 
   method sequence ~sync:bool (updates:Update.t list) =
-    info_f "test_backend::sequence" >>= fun () ->
+    Logger.info_f_ "test_backend::sequence" >>= fun () ->
     let do_one = function
       | Update.Set (k,v) -> self # set k v
       | Update.Delete k  -> self # delete k
@@ -252,7 +252,7 @@ class test_backend my_name = object(self:#backend)
     loop n
 
   method set_interval interval =
-    Lwt_log.debug_f "set_interval %s" (Interval.to_string interval) >>= fun () ->
+    Logger.debug_f_ "set_interval %s" (Interval.to_string interval) >>= fun () ->
     _interval <- interval; Lwt.return ()
   method get_interval () = Lwt.return _interval
 

--- a/src/paxos/multi_paxos.ml
+++ b/src/paxos/multi_paxos.ml
@@ -29,12 +29,12 @@ open Master_type
 
 
 let section =
-  let s = Lwt_log.Section.make "paxos" in
-  let () = Lwt_log.Section.set_level s Lwt_log.Debug in
+  let s = Logger.Section.make "paxos" in
+  let () = Logger.Section.set_level s Logger.Debug in
   s
 
 let log me s =
-  Lwt_log.log ~section ~level:Lwt_log.Debug (me ^ ": " ^ s)
+  Logger.log_ section Logger.Debug (fun () -> (me ^ ": " ^ s))
 
 let log_f me x =
   Printf.ksprintf (log me) x
@@ -50,7 +50,7 @@ exception PaxosFatal of string
 
 let paxos_fatal me fmt =
   let k x =
-    Lwt_log.fatal (me^": "^x) >>= fun () ->
+    Logger.fatal_ (me^": "^x) >>= fun () ->
     Lwt.fail (PaxosFatal x)
   in
   Printf.ksprintf k fmt

--- a/src/paxos/multi_paxos_fsm.ml
+++ b/src/paxos/multi_paxos_fsm.ml
@@ -938,7 +938,7 @@ let enter_forced_slave constants buffers new_i vo=
 	(machine constants) (Slave.slave_fake_prepare constants (new_i,new_n))
     ) 
     (fun exn ->
-      Lwt_log.warning ~exn "FSM BAILED due to uncaught exception" 
+      Logger.warning_ ~exn "FSM BAILED due to uncaught exception" 
       >>= fun () -> Lwt.fail exn
     )
 
@@ -996,7 +996,7 @@ let enter_read_only constants buffers current_i vo =
 	    (read_only constants (current_n, current_i, vo))
     )
     (fun exn ->
-      Lwt_log.warning ~exn "READ ONLY BAILS OUT" >>= fun () ->
+      Logger.warning_ ~exn "READ ONLY BAILS OUT" >>= fun () ->
       Lwt.fail exn
     )
 

--- a/src/paxos/multi_paxos_test.ml
+++ b/src/paxos/multi_paxos_test.ml
@@ -50,7 +50,7 @@ let on_witness who i = ()
 let get_value tlog_coll i = tlog_coll # get_last_value i 
 
 let test_generic network_factory n_nodes () =
-  Lwt_log.info "START:TEST_GENERIC" >>= fun () ->
+  Logger.info_ "START:TEST_GENERIC" >>= fun () ->
   let get_buffer, send, nw_run, nw_register = network_factory () in
   let current_n = 42L
   and current_i = 0L in
@@ -178,7 +178,7 @@ let test_generic network_factory n_nodes () =
   in
   Lwt_list.iter_s 
     (fun (name, update_string) -> 
-      Lwt_log.debug_f "%s:%s"  name update_string) 
+      Logger.debug_f_ "%s:%s"  name update_string) 
     all_consensusses
   >>= fun () ->
   let _ = 
@@ -351,7 +351,7 @@ let test_simulation filters () =
 	Lwt.return ()
       end
     else
-      Lwt_log.debug_f "got (%s,%s,%s) => dropping" msg_s source target
+      Logger.debug_f_ "got (%s,%s,%s) => dropping" msg_s source target
   in
   
   S.make_store "MEM#store"  >>= fun store ->

--- a/src/plugins/plugin_loader.ml
+++ b/src/plugins/plugin_loader.ml
@@ -1,14 +1,16 @@
 open Lwt
 
+let section = Logger.Section.main
+
 let load home pnames = 
   let rec _inner = function
     | [] -> Lwt.return ()
     | p :: ps -> 
-      Lwt_log.info_f "loading plugin %s" p >>= fun () ->
+      Logger.info_f_ "loading plugin %s" p >>= fun () ->
       let pwe = p ^ ".cmo" in
       let full = Filename.concat home pwe in
       let qual = Dynlink.adapt_filename full in
-      Lwt_log.info_f "qualified as: %s" qual >>= fun () ->
+      Logger.info_f_ "qualified as: %s" qual >>= fun () ->
       Dynlink.loadfile_private qual;
       _inner ps 
       in

--- a/src/system/drop_master.ml
+++ b/src/system/drop_master.ml
@@ -3,6 +3,7 @@ open OUnit
 open Master_type
 open Node_cfg.Node_cfg
 
+let section = Logger.Section.main
 
 let setup tn master base () = 
   let lease_period = 10 in
@@ -19,7 +20,7 @@ let _with_master_admin (tn, cluster_cfg, _) f =
   let sp = float(cluster_cfg._lease_period) *. 1.2 in
   Lwt_unix.sleep sp >>= fun () -> (* let the cluster reach stability *) 
   Client_main.find_master cluster_cfg >>= fun master_name ->
-  Lwt_log.info_f "master=%S" master_name >>= fun () ->
+  Logger.info_f_ "master=%S" master_name >>= fun () ->
   let master_cfg =
     List.hd 
       (List.filter (fun cfg -> cfg.node_name = master_name) cluster_cfg.cfgs)
@@ -34,10 +35,10 @@ let _with_master_admin (tn, cluster_cfg, _) f =
     )
 
 let _drop_master cluster_cfg master_name admin = 
-  Lwt_log.info "drop_master scenario" >>= fun () ->
+  Logger.info_ "drop_master scenario" >>= fun () ->
   admin # drop_master () >>= fun () ->
   Client_main.find_master cluster_cfg >>= fun new_master ->
-  Lwt_log.info_f "new? master = %s" new_master >>= fun () ->
+  Logger.info_f_ "new? master = %s" new_master >>= fun () ->
   OUnit.assert_bool "master should have been changed" (new_master <> master_name);
   Lwt.return ()
 

--- a/src/system/startup.ml
+++ b/src/system/startup.ml
@@ -28,6 +28,8 @@ open Update
 open Master_type
 open Tlogcommon
 
+let section = Logger.Section.main
+
 module LS = (val (Store.make_store_module (module Local_store)))
 
 let _make_log_cfg () =
@@ -98,9 +100,9 @@ let _dump_tlc ~tlcs node =
   let printer entry = 
     let i = Entry.i_of entry in
     let v = Entry.v_of entry in
-    Lwt_log.debug_f "%s:%s" (Sn.string_of i) (Value.value2s v) 
+    Logger.debug_f_ "%s:%s" (Sn.string_of i) (Value.value2s v) 
   in
-  Lwt_log.debug_f "--- %s ---" node >>= fun () ->
+  Logger.debug_f_ "--- %s ---" node >>= fun () ->
   tlc0 # iterate Sn.start 20L printer >>= fun () ->
   Lwt.return ()
 
@@ -141,19 +143,19 @@ let post_failure () =
   let eventually_stop () = Lwt_unix.sleep 10.0 
 
   in
-  Lwt_log.debug "start of scenario" >>= fun () ->
+  Logger.debug_ "start of scenario" >>= fun () ->
   Lwt.pick [run_node0 ();
 	    begin Lwt_unix.sleep 5.0 >>= fun () -> run_node1 () end;
 	    run_node2 ();
 	    eventually_stop ()] 
   >>= fun () ->
-  Lwt_log.debug "end of scenario" >>= fun () ->
+  Logger.debug_ "end of scenario" >>= fun () ->
   let check_store node = 
     let db_name = (node ^ "/" ^ node ^".db") in
     let store0 = Hashtbl.find stores db_name in
     let key = "x" in
     LS.exists store0 key >>= fun b ->
-    Lwt_log.debug_f "%s: '%s' exists? -> %b" node key b >>= fun () ->
+    Logger.debug_f_ "%s: '%s' exists? -> %b" node key b >>= fun () ->
     OUnit.assert_bool (Printf.sprintf "value for '%s' should be in store" key) b;
     Lwt.return ()
   in
@@ -195,20 +197,20 @@ let restart_slaves () =
   let run_node1 = _make_run ~stores ~tlcs ~now ~get_cfgs ~values:[v0;v1] node1 in
   (* let run_node2 = _make_run ~stores ~tlcs ~now ~get_cfgs ~updates:[u0;u1] node2 in *)
   let eventually_stop() = Lwt_unix.sleep 10.0 in
-  Lwt_log.debug "start of scenario" >>= fun () ->
+  Logger.debug_ "start of scenario" >>= fun () ->
   Lwt.pick [run_node0 ();
 	    run_node1 ();
 	    (* run_node2 () *)
 	   eventually_stop();
 	   ]
   >>= fun () ->
-  Lwt_log.debug "end of scenario" >>= fun () ->
+  Logger.debug_ "end of scenario" >>= fun () ->
   let check_store node = 
     let db_name = (node ^ "/" ^ node ^".db") in
     let store0 = Hashtbl.find stores db_name in
     let key = "xxx" in
     LS.exists store0 key >>= fun b ->
-    Lwt_log.debug_f "%s: '%s' exists? -> %b" node key b >>= fun () ->
+    Logger.debug_f_ "%s: '%s' exists? -> %b" node key b >>= fun () ->
     OUnit.assert_bool (Printf.sprintf "value for '%s' should be in store" key) b;
     Lwt.return ()
   in
@@ -217,7 +219,7 @@ let restart_slaves () =
     
 
 let setup () = Lwt.return ()
-let teardown () = Lwt_log.debug "teardown"
+let teardown () = Logger.debug_ "teardown"
 
 let w f = Extra.lwt_bracket setup f teardown 
 

--- a/src/tlog/compression.ml
+++ b/src/tlog/compression.ml
@@ -70,12 +70,12 @@ let compress_tlog tlog_name archive_name =
             let cl = String.length contents in
             let ol = String.length output in 
             let factor = (float cl) /. (float ol) in
-	        Lwt_log.debug_f "compression: %i bytes into %i (in %f s) (factor=%2f)" cl ol d factor 
+	        Logger.debug_f Logger.Section.main "compression: %i bytes into %i (in %f s) (factor=%2f)" cl ol d factor 
 	        >>= fun () ->
 	        Llio.output_int64 oc last_i >>= fun () ->
 	        Llio.output_string oc output >>= fun () ->
             let sleep = 2.0 *. d in
-            Lwt_log.debug_f "compression: sleeping %f" sleep >>= fun () ->
+            Logger.debug_f Logger.Section.main "compression: sleeping %f" sleep >>= fun () ->
             Lwt_unix.sleep sleep
 	      in
 	      let buffer = Buffer.create buffer_size in

--- a/src/tlog/compression_test.ml
+++ b/src/tlog/compression_test.ml
@@ -27,7 +27,7 @@ open OUnit
 open Tlogwriter
 open Update
 let test_compress_file () =
-  Lwt_log.info "test_compress_file" >>= fun () ->
+  Logger.info Logger.Section.main "test_compress_file" >>= fun () ->
   let tlog_name = "/tmp/test_compress_file.tlog" in
   Lwt_io.with_file tlog_name ~mode:Lwt_io.output 
     (fun oc -> 

--- a/src/tlog/tlogcommon.ml
+++ b/src/tlog/tlogcommon.ml
@@ -95,8 +95,8 @@ let read_entry ic =
       | End_of_file ->
         begin
           let new_pos = Lwt_io.position ic in 
-          Lwt_log.debug_f "Last valid pos: %d, new pos: %d" (Int64.to_int new_pos) 
-            (Int64.to_int last_valid_pos) >>= fun () ->
+          Logger.log_ Logger.Section.main Logger.Debug (fun () -> Printf.sprintf "Last valid pos: %d, new pos: %d" (Int64.to_int new_pos) 
+            (Int64.to_int last_valid_pos)) >>= fun () ->
           begin 
             if ( Int64.compare new_pos last_valid_pos ) = 0 
             then Lwt.fail End_of_file

--- a/src/tools/backoff.ml
+++ b/src/tools/backoff.ml
@@ -21,7 +21,8 @@ If not, see <http://www.gnu.org/licenses/>.
 *)
 
 open Lwt
-open Lwt_log
+
+let section = Logger.Section.main
 
 let backoff ?(min=0.125) ?(max=8.0) (f:unit -> 'a Lwt.t) =
   let rec loop t = 
@@ -32,7 +33,7 @@ let backoff ?(min=0.125) ?(max=8.0) (f:unit -> 'a Lwt.t) =
        begin 
          let t' = t *. 2.0 in 
      if t' < max then
-       info_f "retrying with timeout of %f" t' >>= fun () ->
+       Logger.info_f_ "retrying with timeout of %f" t' >>= fun () ->
          loop t'
      else Lwt.fail (Failure "max timeout exceeded")
        end

--- a/src/tools/crash_logger.ml
+++ b/src/tools/crash_logger.ml
@@ -23,69 +23,82 @@ If not, see <http://www.gnu.org/licenses/>.
 open Lwt
 
 
+type msg =
+  | Immediate of string * exn option
+  | Delayed of (unit -> string) * exn option
 
-
-type e = {t :float; 
-	  lvl:string;
-	  msg:string}
+type e = {
+  t : float;
+  lvl : string;
+  msg : msg;
+}
 let circ_buf = Lwt_sequence.create()
 let msg_cnt = ref 0
 
-let setup_crash_log crash_file_gen =
+let add_to_crash_log section level msgs =
   let max_crash_log_size = 1000 in
   let level_to_string lvl =
-  begin
-    match lvl with
-      | Lwt_log.Debug -> "debug"
-      | Lwt_log.Info -> "info"
-      | Lwt_log.Notice -> "notice"
-      | Lwt_log.Warning -> "warning"
-      | Lwt_log.Error -> "error" 
-      | Lwt_log.Fatal -> "fatal"
-  end 
+    begin
+      match lvl with
+        | Lwt_log.Debug -> "debug"
+        | Lwt_log.Info -> "info"
+        | Lwt_log.Notice -> "notice"
+        | Lwt_log.Warning -> "warning"
+        | Lwt_log.Error -> "error"
+        | Lwt_log.Fatal -> "fatal"
+    end
   in
-  
+
   let rec remove_n_elements = function
     | 0  -> ()
-    | n -> 
-      let _ = Lwt_sequence.take_opt_l circ_buf in
-      let () = decr msg_cnt in
-      remove_n_elements (n-1)
+    | n ->
+        let _ = Lwt_sequence.take_opt_l circ_buf in
+        let () = decr msg_cnt in
+        remove_n_elements (n-1)
   in
-  
+
   let add_msg lvl msg  =
     let () = incr msg_cnt in
     let e = {t = Unix.time();lvl = lvl; msg = msg} in
     let _ = Lwt_sequence.add_r e circ_buf  in
     ()
   in
-  
-  let add_to_crash_log section level msgs =
-    let new_msg_cnt = List.length msgs in
-    let total_msgs = !msg_cnt + new_msg_cnt in
-    let () = 
-      if  total_msgs > 2 * max_crash_log_size then
-	begin
-	  let to_delete = total_msgs - max_crash_log_size in
-	  (* let () = Printf.printf "removing %i%!\n" to_delete in *)
-	  remove_n_elements to_delete;
-	  (* Gc.compact() *)
-	end
-    in
-    let lvls = level_to_string level in
-    let () = List.iter (add_msg lvls) msgs  in
-    Lwt.return () 
-  in 
-  
-  let dump_crash_log () =  
+  let new_msg_cnt = List.length msgs in
+  let total_msgs = !msg_cnt + new_msg_cnt in
+  let () =
+    if  total_msgs > 2 * max_crash_log_size then
+	  begin
+	    let to_delete = total_msgs - max_crash_log_size in
+	      (* let () = Printf.printf "removing %i%!\n" to_delete in *)
+	    remove_n_elements to_delete;
+	    (* Gc.compact() *)
+	  end
+  in
+  let lvls = level_to_string level in
+  let () = List.iter (add_msg lvls) msgs  in
+  Lwt.return ()
+
+
+let setup_crash_log crash_file_gen =
+  let dump_crash_log () =
     let dump_msgs oc =
       let rec loop () =
 
-	let e = Lwt_sequence.take_l circ_buf in
-	let msg = Printf.sprintf "%Ld: %s: %s" 
-	  (Int64.of_float e.t) e.lvl e.msg in
-	Lwt_io.write_line oc msg >>= fun () ->
-	loop ()
+        let e = Lwt_sequence.take_l circ_buf in
+        let append_exn m exn =
+          match exn with
+            | None -> m
+            | Some exn -> m ^ Printexc.to_string exn in
+        let msg =
+          Printf.sprintf
+            "%Ld: %s: %s"
+            (Int64.of_float e.t)
+            e.lvl
+            (match e.msg with
+              | Immediate (m, exn) -> append_exn m exn
+              | Delayed (fm, exn) -> append_exn (fm ()) exn) in
+        Lwt_io.write_line oc msg >>= fun () ->
+        loop ()
       in
       Lwt.catch 
 	loop
@@ -127,7 +140,7 @@ let setup_default_logger file_log_path crash_log_prefix =
     Lwt.catch
       (fun () ->
         Lwt_list.iter_s log_file_msg msgs >>= fun () -> 
-        log_crash_msg section level msgs )
+        log_crash_msg section level (List.map (fun m -> Immediate (m, None)) msgs) )
       (function 
         | Lwt_log.Logger_closed -> Lwt.return ()
         | e -> Lwt.fail e
@@ -142,8 +155,4 @@ let setup_default_logger file_log_path crash_log_prefix =
   let default_logger = Lwt_log.make add_log_msg close_default_logger in
   Lwt_log.default := default_logger;
   Lwt.return dump_crash_log
-   
-
-      
-
 

--- a/src/tools/file_system.ml
+++ b/src/tools/file_system.ml
@@ -22,8 +22,10 @@ If not, see <http://www.gnu.org/licenses/>.
 
 open Lwt
 
+let section = Logger.Section.main
+
 let copy_file source target = (* LOOKS LIKE Clone.copy_stream ... *)
-  Lwt_log.debug_f "copy_file %s %s" source target >>= fun () ->
+  Logger.debug_f_ "copy_file %s %s" source target >>= fun () ->
   let bs = Lwt_io.default_buffer_size () in
   let buffer = String.create bs in
   let copy_all ic oc = 
@@ -38,7 +40,7 @@ let copy_file source target = (* LOOKS LIKE Clone.copy_stream ... *)
 	Lwt.return ()    
     in
     loop () >>= fun () ->
-    Lwt_log.debug "done: copy_file" 
+    Logger.debug_ "done: copy_file" 
   in
   Lwt_io.with_file ~mode:Lwt_io.input source
     (fun ic ->
@@ -67,11 +69,11 @@ let lwt_directory_list dn =
         (fun () -> loop [])
         (fun () -> Lwt_unix.closedir h)
     )
-    (fun exn -> Lwt_log.debug_f ~exn "lwt_directory_list %s" dn >>= fun () -> Lwt.fail exn)
+    (fun exn -> Logger.debug_f_ ~exn "lwt_directory_list %s" dn >>= fun () -> Lwt.fail exn)
 
 
 let rename source target = 
-  Lwt_log.debug_f "rename %s -> %s" source target >>= fun () ->
+  Logger.debug_f_ "rename %s -> %s" source target >>= fun () ->
   Lwt_unix.rename source target
 
 let mkdir name = Lwt_unix.mkdir name
@@ -80,7 +82,7 @@ let unlink name = Lwt_unix.unlink name
 let rmdir name = Lwt_unix.rmdir name
 
 let stat filename = 
-  Lwt_log.debug_f "stat %s" filename >>= fun () ->
+  Logger.debug_f_ "stat %s" filename >>= fun () ->
   Lwt_unix.stat filename
 
 let exists filename = 

--- a/src/tools/logger.ml
+++ b/src/tools/logger.ml
@@ -1,0 +1,37 @@
+open Lwt
+
+module Section =
+struct
+  let make = Lwt_log.Section.make
+  let set_level = Lwt_log.Section.set_level
+  let level = Lwt_log.Section.level
+  let main = Lwt_log.Section.main
+end
+
+type level =
+    Lwt_log.level =
+  | Debug
+  | Info
+  | Notice
+  | Warning
+  | Error
+  | Fatal
+
+let log ?exn section level msg =
+  if level < Lwt_log.Section.level section
+  then
+    Crash_logger.add_to_crash_log section level [Crash_logger.Immediate (msg, exn)]
+  else
+    match exn with
+      | Some exn -> Lwt_log.log ~exn ~section ~level msg
+      | None -> Lwt_log.log ~section ~level msg
+
+let log_ ?exn section level dmsg =
+  if level < Lwt_log.Section.level section
+  then
+    Crash_logger.add_to_crash_log section level [Crash_logger.Delayed (dmsg, exn)]
+  else
+    match exn with
+      | Some exn -> Lwt_log.log ~exn ~section ~level (dmsg ())
+      | None -> Lwt_log.log ~section ~level (dmsg ())
+

--- a/src/tools/lwt_buffer.ml
+++ b/src/tools/lwt_buffer.ml
@@ -62,7 +62,7 @@ module Lwt_buffer = struct
         if _is_full t 
         then 
 	      if t.leaky
-	      then Lwt.return () (* Lwt_log.debug "leaky buffer reached capacity: dropping" *)
+	      then Lwt.return () (* Logger.debug "leaky buffer reached capacity: dropping" *)
 	      else
 	        begin
 	          Lwt_condition.wait (* ~mutex:t.full_m *) t.full >>= fun () ->

--- a/src/tools/network.ml
+++ b/src/tools/network.ml
@@ -19,8 +19,10 @@ You should have received a copy of the
 GNU Affero General Public License along with this program (file "COPYING").
 If not, see <http://www.gnu.org/licenses/>.
 *)
+
 open Lwt
 
+let section = Logger.Section.main
 
 let make_address host port =
   let ha = Unix.inet_addr_of_string host in
@@ -47,14 +49,14 @@ let __open_connection socket_address =
       >>= fun () ->
       let fd_field = Obj.field (Obj.repr socket) 0 in
       let (fdi:int) = Obj.magic (fd_field) in
-      Lwt_log.info_f "__open_connection SUCCEEDED (fd=%i) %s %s" fdi
+      Logger.info_f_ "__open_connection SUCCEEDED (fd=%i) %s %s" fdi
 	    (a2s a2) (a2s peer)
       >>= fun () ->
       let oc = Lwt_io.of_fd ~mode:Lwt_io.output socket in
       let ic = Lwt_io.of_fd ~mode:Lwt_io.input  socket in
       Lwt.return (ic,oc))
     (fun exn -> 
-      Lwt_log.info_f ~exn "__open_connection to %s failed" (a2s socket_address)
+      Logger.info_f_ ~exn "__open_connection to %s failed" (a2s socket_address)
       >>= fun () ->
       Lwt_unix.close socket >>= fun () ->
       Lwt.fail exn)


### PR DESCRIPTION
This pull request fixes the crash_logging and implements the optimization in which strings for the crashlogger are only computed when needed.
The lazyness is implemented by the type Crash_logger.msg which is either an immediate string or a (unit -> string).
Some syntactic sugar for this has been added in the form macros.

Logger.{debug/info/...}_f section "format%s string" "bla"
->
Logger.log_ Logger.{Debug/Info/...} section (fun () -> Printf.sprintf "format%s string" "bla")

macros ending with _ also capture the variable 'section' which is expected to be defined in the environment, e.g.:

Logger.{debug/info/...}_f_ "format%s string" "bla"
->
Logger.log_ Logger.{Debug/Info/...} section (fun () -> Printf.sprintf "format%s string" "bla")

I tried to eliminate all usages of Lwt_log (except in the modules specifically dealing with logging ofcourse). Some usages are still left but these are not statements doing logging themselves; if desired I can centralize this into the logger module too.
