### PR TITLE
Enable warnings-as-errors & fix compilation accordingly

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,5 +1,6 @@
 true: debug
 true: annot
+true: warn_error
 true: package(lwt)
 true: package(lwt.preemptive)
 true: package(lwt.unix)

--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -433,7 +433,6 @@ let _main_2 (type s)
 	        (fun () -> make_tlog_coll me.tlog_dir me.use_compression name ) 
 	        (function 
               | Tlc2.TLCCorrupt (pos,tlog_i) ->
-                let store_i = S.consensus_i store in
                 Tlc2.get_last_tlog me.tlog_dir >>= fun (last_c, last_tlog) ->
                 let tlog_i = 
                   begin

--- a/src/paxos/multi_paxos.ml
+++ b/src/paxos/multi_paxos.ml
@@ -272,8 +272,7 @@ let handle_prepare (type s) constants dest n n' i' =
 		        | Some si -> Sn.succ si
 	        end 
           in
-          let lv = constants.get_value nak_max in
-          
+
           if ( n' > n && i' < nak_max && nak_max <> Sn.start ) || n' <= n 
           then
             (* Send Nak, other node is behind *)

--- a/src/tlog/tlogcollection_test.ml
+++ b/src/tlog/tlogcollection_test.ml
@@ -122,7 +122,7 @@ let test_restart (dn, factory) =
   _log_repeat tlc_one value 100 >>= fun () ->
   tlc_one # close () >>= fun () ->
   factory dn "node_name" >>= fun tlc_two ->
-  let uo = tlc_two # get_last_value (Sn.of_int 99) in
+  let _ = tlc_two # get_last_value (Sn.of_int 99) in
   tlc_two # close () >>= fun () ->
   Lwt.return ()
 

--- a/src/tlog/update_test.ml
+++ b/src/tlog/update_test.ml
@@ -76,16 +76,16 @@ let test_delete_prefix () =
   _cmp u u' 
 
 let test_assert ()=
-  let u1= Update.Set ("keyi", "valuei") in
-  let u2 = Update.Assert ("key", Some "value") in
-  let u' = _b2b u2 in
-  _cmp u2 u'
+  let _ = Update.Set ("keyi", "valuei") in
+  let u = Update.Assert ("key", Some "value") in
+  let u' = _b2b u in
+  _cmp u u'
 
 let test_assert_exists () =
-  let ui= Update.Set ("keyi", "valuei") in
-  let ua = Update.Assert_exists ("keyi") in
-  let u' = _b2b ua in
-  _cmp ua u'
+  let _= Update.Set ("keyi", "valuei") in
+  let u = Update.Assert_exists ("keyi") in
+  let u' = _b2b u in
+  _cmp u u'
 (*
   let u = Update.Set ("key2", "value")in
   let u2 = Update.Assert_exists ("mkey")in


### PR DESCRIPTION
CI -base is running, build succeeded, changes shouldn't influence test outcome.
