### PR TITLE
Error-out if BDBFFATAL flag is set on TokyoCabinet database

### DIFF
--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -649,6 +649,10 @@ let _main_2 (type s)
               let rc = 44 in
               Logger.fatal_f_ "[rc=%i] Missing or inaccessible home directory: %s" rc dir >>= fun () ->
               Lwt.return rc
+          | Local_store.BdbFFatal db ->
+              let rc = 45 in
+              Logger.fatal_f_ "[rc=%i] BDBFFATAL flag set on database %s" rc db >>= fun () ->
+              Lwt.return rc
           | exn -> 
               begin
 	            Logger.fatal_ ~exn "going down" >>= fun () ->


### PR DESCRIPTION
When a TokyoCabinet database is opened, the flags contained in the file
are retrieved, and checked for `BDBFFATAL`. If this flag is set, and
exception is thrown which results in the Arakoon process to quit with
return code 45.

For testing purposes, a TokyoCabinet file can be 'broken' manually by
setting bit 2 of the 34th byte in the database file.

See: ARAKOON-393
See: http://jira.incubaid.com/browse/ARAKOON-393
