### PR TITLE
Extension: Pass '-n' to 'pgrep'

### DIFF
--- a/extension/server/ArakoonManagement.py
+++ b/extension/server/ArakoonManagement.py
@@ -1086,7 +1086,7 @@ class ArakoonCluster:
                 
     def _getStatusOne(self,name):
         line = self._cmdLine(name)
-        cmd = ['pgrep','-f', line]
+        cmd = ['pgrep','-fn', line]
         proc = subprocess.Popen(cmd,
                                 close_fds = True,
                                 stdout=subprocess.PIPE)


### PR DESCRIPTION
In order not to match any intermediate 'wrapper' scripts, a process
table lookup should only match the 'last' process.

See: ARAKOON-406
See: http://jira.incubaid.com/browse/ARAKOON-406
