### PR TITLE
Add configuration option to 'fsync' after every tlog modification

### DIFF
--- a/extension/server/ArakoonManagement.py
+++ b/extension/server/ArakoonManagement.py
@@ -535,6 +535,28 @@ class ArakoonCluster:
         """
         self._changeTlogCompression(nodes, 'true')
 
+
+    def _changeFsync(self, nodes, value):
+        if nodes is None:
+            nodes = self.listNodes()
+        else:
+            for n in nodes:
+                self.__validateName(n)
+
+        config = self._getConfigFile()
+
+        for node in nodes:
+            config.addParam(node, 'fsync', value)
+
+    def enableFsync(self, nodes=None):
+        '''Enable fsync'ing of tlogs after every operation'''
+        self._changeFsync(nodes, 'true')
+
+    def disableFsync(self, nodes=None):
+        '''Disable fsync'ing of tlogs after every operation'''
+        self._changeFsync(nodes, 'false')
+
+
     def setReadOnly(self, flag = True):
         config = self._getConfigFile()
         if flag and len(self.listNodes()) <> 1:

--- a/extension/test/server/right/system_tests_long_right.py
+++ b/extension/test/server/right/system_tests_long_right.py
@@ -527,7 +527,16 @@ def test_disable_tlog_compression():
     tlog_len = len(tlogs)
     assert_equals(tlog_len, expected, 
                   "Wrong number of uncompressed tlogs (%d != %d)" % (expected, tlog_len)) 
- 
+
+@Common.with_custom_setup(Common.default_setup, Common.basic_teardown)
+def test_fsync():
+    c = _getCluster()
+    c.enableFsync()
+    c.restart()
+    time.sleep(2)
+    c.disableFsync()
+    c.restart()
+    time.sleep(2)
 
 @Common.with_custom_setup(Common.setup_1_node, Common.basic_teardown)
 def test_sabotage():

--- a/src/node/catchup_test.ml
+++ b/src/node/catchup_test.ml
@@ -110,7 +110,7 @@ let setup () =
     
 let test_common () =
   Logger.info_ "test_common" >>= fun () ->
-  Tlc2.make_tlc2 _dir_name true "node_name" >>= fun tlog_coll ->
+  Tlc2.make_tlc2 _dir_name true false "node_name" >>= fun tlog_coll ->
   _fill tlog_coll 1000 >>= fun () ->
   let me = "" in
   let db_name = _dir_name ^ "/my_store1.db" in
@@ -136,7 +136,7 @@ let teardown () =
 
 let _tic (type s) filler_function n name verify_store =
   Tlogcommon.tlogEntriesPerFile := 101;
-  Tlc2.make_tlc2 _dir_name true "node_name" >>= fun tlog_coll ->
+  Tlc2.make_tlc2 _dir_name true false "node_name" >>= fun tlog_coll ->
   filler_function tlog_coll n >>= fun () ->
   let tlog_i = Sn.of_int n in
   let db_name = _dir_name ^ "/" ^ name ^ ".db" in

--- a/src/node/collapser_test.ml
+++ b/src/node/collapser_test.ml
@@ -59,7 +59,7 @@ let _make_values tlc n =
 let test_collapse_until dn = 
   let () = Tlogcommon.tlogEntriesPerFile := 1000 in
   Logger.debug_f_ "dn=%s" dn >>= fun () ->
-  Tlc2.make_tlc2 dn true "node_name" >>= fun tlc ->
+  Tlc2.make_tlc2 dn true false "node_name" >>= fun tlc ->
   _make_values tlc 1111 >>= fun () ->
   tlc # close () >>= fun () ->
   Lwt_unix.sleep 5.0 >>= fun () -> (* give it time to generate the .tlc *)
@@ -97,7 +97,7 @@ let test_dn = "/tmp/collapser"
 let test_collapse_many dn =
   let () = Tlogcommon.tlogEntriesPerFile := 100 in
   Logger.debug_f_ "test_collapse_many_regime dn=%s" dn >>= fun () ->
-  Tlc2.make_tlc2 dn true "node_name" >>= fun tlc ->
+  Tlc2.make_tlc2 dn true false "node_name" >>= fun tlc ->
   _make_values tlc 632 >>= fun () ->
   tlc # close () >>= fun () ->
   Lwt_unix.sleep 5.0 >>= fun () -> (* compression finished ? *) 

--- a/src/node/node_cfg.ml
+++ b/src/node/node_cfg.ml
@@ -54,6 +54,7 @@ module Node_cfg = struct
         is_learner : bool;
         targets : string list;
         use_compression : bool;
+        fsync : bool;
         is_test : bool;
         reporting: int;
        }
@@ -67,7 +68,7 @@ module Node_cfg = struct
         "log_dir=%S; log_level:%S; log_config=%s; " ^^
         "batched_transaction_config=%s; lease_period=%i; " ^^
         "master=%S; is_laggy=%b; is_learner=%b; " ^^
-        "targets=%s; use_compression=%b; is_test=%b; " ^^
+        "targets=%s; use_compression=%b; fsync=%b; is_test=%b; " ^^
         "reporting=%i; " ^^
         "}"
     in
@@ -79,7 +80,7 @@ module Node_cfg = struct
       t.log_dir t.log_level (_so2s t.log_config)
       (_so2s t.batched_transaction_config) t.lease_period
       (master2s t.master) t.is_laggy t.is_learner
-      (list2s (fun s -> s) t.targets) t.use_compression t.is_test
+      (list2s (fun s -> s) t.targets) t.use_compression t.fsync t.is_test
       t.reporting
 
   type log_cfg =
@@ -181,6 +182,7 @@ module Node_cfg = struct
         is_learner = false;
         targets = [];
         use_compression = true;
+        fsync = false;
         is_test = true;
         reporting = 300;
       }
@@ -353,6 +355,7 @@ module Node_cfg = struct
     let is_laggy = get_bool "laggy" in
     let is_learner = get_bool "learner" in
     let use_compression = not (get_bool "disable_tlog_compression") in
+    let fsync = get_bool "fsync" in
     let targets = 
       if is_learner 
       then Ini.get inifile node_name "targets" Ini.p_string_list Ini.required 
@@ -380,6 +383,7 @@ module Node_cfg = struct
      is_learner;
      targets;
      use_compression;
+     fsync;
      is_test = false;
      reporting;
     }

--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -206,7 +206,7 @@ let only_catchup (type s) (module S : Store.STORE with type t = s) ~name ~cluste
     end
   in
   S.make_store db_name >>= fun store ->
-  make_tlog_coll me.tlog_dir me.use_compression name >>= fun tlc ->
+  make_tlog_coll me.tlog_dir me.use_compression me.fsync name >>= fun tlc ->
   let current_i = Sn.start in
   let future_n = Sn.start in
   let future_i = Sn.start in
@@ -445,7 +445,7 @@ let _main_2 (type s)
             end
           in
 	      Lwt.catch
-	        (fun () -> make_tlog_coll me.tlog_dir me.use_compression name ) 
+	        (fun () -> make_tlog_coll me.tlog_dir me.use_compression me.fsync name)
 	        (function 
               | Tlc2.TLCCorrupt (pos,tlog_i) ->
                 Tlc2.get_last_tlog me.tlog_dir >>= fun (last_c, last_tlog) ->
@@ -468,7 +468,7 @@ let _main_2 (type s)
                       Logger.warning_f_ "Invalid tlog file found. Auto-truncating tlog %s" 
 			            last_tlog >>= fun () ->
                       let _ = Tlc2.truncate_tlog last_tlog in
-                      make_tlog_coll me.tlog_dir me.use_compression name
+                      make_tlog_coll me.tlog_dir me.use_compression me.fsync name
 		            end
                   else 
 		            begin
@@ -676,7 +676,7 @@ let main_t make_config name daemonize catchup_only : int Lwt.t =
     
 let test_t make_config name =
   let module S = (val (Store.make_store_module (module Mem_store))) in
-  let make_tlog_coll = Mem_tlogcollection.make_mem_tlog_collection in
+  let make_tlog_coll = fun a b _ d -> Mem_tlogcollection.make_mem_tlog_collection a b d in
   let get_snapshot_name = fun () -> "DUMMY" in
   let daemonize = false 
   and catchup_only = false in

--- a/src/system/startup.ml
+++ b/src/system/startup.ml
@@ -65,11 +65,12 @@ let _make_cfg name n lease_period =
     is_learner = false;
     targets = [];
     use_compression = true;
+    fsync = false;
     is_test = true;
     reporting = 300;
   }
 
-let _make_tlog_coll tlcs values tlc_name use_compression node_id = 
+let _make_tlog_coll tlcs values tlc_name use_compression fsync node_id =
   Mem_tlogcollection.make_mem_tlog_collection tlc_name use_compression node_id >>= fun tlc ->
   let rec loop i = function
     | [] -> Lwt.return () 

--- a/src/tlog/tlc2_test.ml
+++ b/src/tlog/tlc2_test.ml
@@ -30,7 +30,7 @@ open Tlogcommon
 
 let section = Logger.Section.main
 
-let create_test_tlc dn = Tlc2.make_tlc2 dn true
+let create_test_tlc dn = Tlc2.make_tlc2 dn true false
 let wrap_tlc = Tlogcollection_test.wrap create_test_tlc 
 
 let prepare_tlog_scenarios (dn,factory) =


### PR DESCRIPTION
Using the new 'fsync' configuration boolean (used in a node
configuration section), an fsync(2) call will be issued after every
modification of a tlog file.

See: ARAKOON-389
See: http://jira.incubaid.com/browse/ARAKOON-389
