### PR TITLE
only retry catchup connection on another ip if connection never successf...

### DIFF
--- a/src/node/catchup.ml
+++ b/src/node/catchup.ml
@@ -35,23 +35,34 @@ type store_tlc_cmp =
   | Store_tlc_equal
   | Store_ahead
 
-let _with_client_connection (ips,port) f = 
+let _with_client_connection (ips,port) f =
   let sl2s ss = list2s (fun s -> s) ss in
   let rec loop = function
     | [] -> Llio.lwt_failfmt "None of the ips: %s can be reached" (sl2s ips)
     | ip :: rest ->
-      Lwt.catch
-        (fun () ->
-          let address = Network.make_address ip port in
-          Lwt_io.with_connection address f
-        )
-        (fun exn -> 
-          Lwt_log.info_f ~exn "ip = %s " ip >>= fun () ->
-          loop rest
-        )
+        Lwt.catch
+          (fun () ->
+            let address = Network.make_address ip port in
+            Lwt_io.with_connection address f)
+          (fun exn ->
+            Lwt_log.info_f ~exn "ip = %s " ip >>= fun () ->
+            match exn with
+              | Unix.Unix_error(error,_,_) ->
+                  begin
+                    match error with
+                      | Unix.ECONNREFUSED
+                      | Unix.ENETUNREACH
+                      | Unix.EHOSTUNREACH
+                      | Unix.EHOSTDOWN ->
+                          loop rest
+                      | _ -> Lwt.fail exn
+                  end
+              | Lwt_unix.Timeout ->
+                  loop rest
+              | _ -> Lwt.fail exn)
   in
   loop ips
-      
+
 
 let compare_store_tlc store tlc =
   store # consensus_i () >>= fun m_store_i ->

--- a/src/node/sync_backend.ml
+++ b/src/node/sync_backend.ml
@@ -414,7 +414,12 @@ object(self: #backend)
           and u = Entry.u_of entry
           in
           Tlogcommon.write_entry oc i u in
-	    tlog_collection # iterate start_i3 too_far_i f >>= fun () ->
+	    Lwt.catch
+          (fun () -> tlog_collection # iterate start_i3 too_far_i f)
+          (function
+            | Tlogcommon.TLogCheckSumError _ -> Lwt.return ()
+            | exn -> Lwt.fail exn)
+        >>= fun () ->
 	    Sn.output_sn oc (-1L)
 	  end
     end


### PR DESCRIPTION
...ully opened

providing last_entries in sync_backend shouldn't fail on TLogCheckSumError

This differs slightly from https://github.com/Incubaid/arakoon/pull/83
