### PR TITLE
PyLabs: Return RC mapping after cluster start/restart

### DIFF
--- a/extension/server/ArakoonManagement.py
+++ b/extension/server/ArakoonManagement.py
@@ -876,8 +876,12 @@ class ArakoonCluster:
         """
         start all nodes in the cluster
         """
+        rcs = {}
+
         for name in self.listLocalNodes():
-            self._startOne(name)
+            rcs[name] = self._startOne(name)
+
+        return rcs
 
     def stop(self):
         """
@@ -895,8 +899,12 @@ class ArakoonCluster:
         
         @param clusterId the arakoon cluster name
         """
+        rcs = {}
+
         for name in self.listLocalNodes():
-            self._restartOne(name)
+            rcs[name] = self._restartOne(name)
+
+        return rcs
 
     def getStatus(self):
         """

--- a/extension/test/server/quick/TestCmdTools.py
+++ b/extension/test/server/quick/TestCmdTools.py
@@ -86,7 +86,10 @@ class TestCmdTools:
 
     def testStart(self):
         cluster = self._getCluster()
-        cluster.start()
+        rcs = cluster.start()
+
+        assert set(rcs.iterkeys()) == set(cluster.listNodes())
+
         self._assert_n_running(3)
 
         #starting twice should not throw anything
@@ -109,7 +112,10 @@ class TestCmdTools:
 
     def testRestart(self):
         cluster = self._getCluster()
-        cluster.start()
+        rcs = cluster.start()
+
+        assert set(rcs.iterkeys()) == set(cluster.listNodes())
+
         self._assert_n_running(3)
 
         cluster.restart()


### PR DESCRIPTION
See: ARAKOON-383
See: http://jira.incubaid.com/browse/ARAKOON-383
Fixes: ARAKOON-409
See: http://jira.incubaid.com/browse/ARAKOON-409

CI -base & -quick passed (or rather, failed with unrelated errors)
