### PR TITLE
fix concurrent collapse test

### DIFF
--- a/extension/test/server/shaky/test_concurrent_collapse_fails.py
+++ b/extension/test/server/shaky/test_concurrent_collapse_fails.py
@@ -58,7 +58,7 @@ def test_concurrent_collapse_fails():
             if rc == 255:
                 self.exception_received = True
 
-    s = SecondCollapseThread(8)
+    s = SecondCollapseThread(4)
     assert not s.exception_received
 
     logging.info('Launching second collapser thread')


### PR DESCRIPTION
While analyzing the log of this failed test I noticed that instead of being concurrent the collapses came after each other. This change should fix that.
