### PR TITLE
inject client update event in ignored thread so it can't make the paxos fsm hang

### DIFF
--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -531,7 +531,8 @@ let _main_2 (type s)
               (Multi_paxos.paxos_event2s e)
               name 
             >>= fun () ->
-	        Lwt_buffer.add e buffer
+	        Lwt_buffer.add e buffer >>= fun () ->
+            Logger.debug_f Multi_paxos.section "XXX injected event into '%s'" name
 	      in
 	      let buffers = Multi_paxos_fsm.make_buffers
 	        (client_buffer,

--- a/src/paxos/master.ml
+++ b/src/paxos/master.ml
@@ -40,7 +40,8 @@ let master_consensus constants ((finished_funs : master_option),v,n,i, lease_exp
     match v with
     | Value.Vm _ ->
       let event = Multi_paxos.FromClient [(Update.Nop, fun _ -> Lwt.return ())] in
-      constants.inject_event event
+      Lwt.ignore_result (constants.inject_event event);
+      Lwt.return ()
     | _ -> Lwt.return ()
   )
   in


### PR DESCRIPTION
CI looks good so far (3 runs of the drop master tests)
