### PR TITLE
throw TLogUnexcpectedEndOfFile when reaching the end of the tlog unexpec...

### DIFF
--- a/src/node/sync_backend.ml
+++ b/src/node/sync_backend.ml
@@ -384,7 +384,11 @@ object(self: #backend)
           and v = Entry.v_of entry
           in
           Tlogcommon.write_entry oc i v in
-	    tlog_collection # iterate start_i3 too_far_i f >>= fun () ->
+        Lwt.catch
+          (fun () -> tlog_collection # iterate start_i3 too_far_i f)
+          (function
+            | Tlogcommon.TLogUnexpectedEndOfFile _ -> Lwt.return ()
+            | ex -> Lwt.fail ex) >>= fun () ->
 	    Sn.output_sn oc (-1L)
 	  end
     end

--- a/src/tlog/tlc2.ml
+++ b/src/tlog/tlc2.ml
@@ -216,7 +216,8 @@ let _validate_one tlog_name node_id ~check_marker : validation_result Lwt.t =
     )
     (function
       | Unix.Unix_error(Unix.ENOENT,_,_) -> Lwt.return (None, new_index)
-      | Tlogcommon.TLogCheckSumError pos ->
+      | Tlogcommon.TLogCheckSumError pos
+      | Tlogcommon.TLogUnexpectedEndOfFile pos ->
         begin
           match !prev_entry with
             | Some entry -> let i = Entry.i_of entry in Lwt.fail (TLCCorrupt (pos,i))
@@ -811,7 +812,8 @@ let truncate_tlog filename =
           Lwt.catch
             (fun() -> folder ic ~index lowerI higherI ~first () skipper)
             (function
-              | Tlogcommon.TLogCheckSumError pos ->
+              | Tlogcommon.TLogCheckSumError pos
+              | Tlogcommon.TLogUnexpectedEndOfFile pos ->
                 let fd = Unix.openfile filename [ Unix.O_RDWR ] 0o600 in
                 Lwt.return ( Unix.ftruncate fd (Int64.to_int pos) )
               | ex -> Lwt.fail ex


### PR DESCRIPTION
...tedly, and treat as a TLogCheckSumError in most places

This fixes a bug in truncating introduced in 2f2371e305f677a17c4c19e32b82f38fdc5b9369
