### PR TITLE
Pylabs: Dump crash log before using SIGKILL

### DIFF
--- a/extension/server/ArakoonManagement.py
+++ b/extension/server/ArakoonManagement.py
@@ -32,6 +32,7 @@ import itertools
 import subprocess
 import time
 import types
+import signal
 import string
 import logging
 
@@ -1148,6 +1149,12 @@ class ArakoonCluster:
             q.logger.log("'%s' is still running... waiting" % name, level = 3)
 
             if i == 10:
+                msg = "Requesting '%s' to dump crash log information" % name
+                logging.debug(msg)
+                q.logger.log(msg, level=3)
+                subprocess.call(['pkill', '-%d' % signal.SIGUSR2, '-f', line], close_fds=True)
+                time.sleep(1)
+
                 logging.debug("stopping '%s' with kill -9" % name)
                 q.logger.log("stopping '%s' with kill -9" % name, level = 3)
                 rc = subprocess.call(['pkill', '-9', '-f', line], close_fds = True)


### PR DESCRIPTION
For investigation purposes, it's useful to have access to the node
crash log content when needing to kill it using `SIGKILL` (if it
doesn't quit after `SIGTERM` in time).

With this change the extension `stop` method sends `SIGUSR2` to the
process before sending `SIGKILL`.

See: 7f77f2fd6b9733affb0f9ecadbbcb75ec8e242b7
See: #127
