### PR TITLE
Bump all logging to debug level after SIGTERM/SIGINT

### DIFF
--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -593,7 +593,14 @@ let _main_2 (type s)
                         (listen_for_signal () >>= fun () ->
                          let msg = "got TERM | INT" in
                          Logger.info_ msg >>= fun () ->
-                         Lwt_io.printl msg
+                         Lwt_io.printl msg >>= fun () ->
+                         Lwt_log.Section.set_level Lwt_log.Section.main Lwt_log.Debug;
+                         List.iter
+                           (fun n ->
+                             let s = Lwt_log.Section.make n in
+                             Lwt_log.Section.set_level s Lwt_log.Debug)
+                           ["client_protocol"; "tcp_messaging"; "paxos"];
+                         Logger.info_ "All logging set to debug level after TERM/INT"
                         )
                         ;
                       ])


### PR DESCRIPTION
For investigation & debugging purposes it's useful to know what happens
after a node receives SIGTERM or SIGINT (e.g. to figure out why it's
taking a long time to quit). This change makes sure all logging is
bumped to debug level, ignoring any prior configuration.

See: ARAKOON-416
See: http://jira.incubaid.com/browse/ARAKOON-416
