### PR TITLE
insert ElectionTimeout before going to Accepteds_check_done

### DIFF
--- a/src/paxos/master.ml
+++ b/src/paxos/master.ml
@@ -40,35 +40,27 @@ let master_consensus (type s) constants ((finished_funs : master_option),v,n,i, 
       Printf.sprintf "on_consensus for : %s => %i finished_fs (in master_consensus)"
         (Value.value2s v) (List.length finished_funs) )
   in
-  let module S = (val constants.store_module : Store.STORE with type t = s) in
-  match (Value.is_master_set v, is_empty lease_expire_waiters, S.who_master constants.store) with
-    | false, false, None ->
-      (* there is no master, this ain't a masterset, and there is no drop master going on
-         so let's push MasterSet for myself *)
-      let mv =Value.create_master_value (constants.me, 0L) in
-      let i' = Sn.succ i in
-      push_value constants mv n i' >>= fun () ->
-      let nnodes = List.length constants.others + 1 in
-      let needed = constants.quorum_function nnodes in
-      let new_ballot = (needed-1 , [constants.me] ) in
-      Fsm.return
-        ~sides:[con_e;log_e]
-        (Accepteds_check_done ([(fun _ -> Lwt.return ())], n, i', new_ballot, mv, []))
-    | _ ->
-      begin
-        let inject_e = EGen (fun () ->
-            match v with
-              | Value.Vm _ ->
-                let event = Multi_paxos.FromClient [(Update.Nop, fun _ -> Lwt.return ())] in
-                Lwt.ignore_result (constants.inject_event event);
-                Lwt.return ()
-              | _ ->
-                Lwt.return ()
-          )
-        in
-        let state = (v,n,(Sn.succ i), lease_expire_waiters) in
-        Fsm.return ~sides:[con_e;log_e;inject_e] (Stable_master state)
-      end
+  let inject_e = EGen (fun () ->
+      match v with
+        | Value.Vm _ ->
+          let event = Multi_paxos.FromClient [(Update.Nop, fun _ -> Lwt.return ())] in
+          Lwt.ignore_result (constants.inject_event event);
+          Lwt.return ()
+        | _ ->
+          begin
+            let module S = (val constants.store_module : Store.STORE with type t = s) in
+            let () = match S.who_master constants.store with
+              | None ->
+                let event = Multi_paxos.LeaseExpired n in
+                Lwt.ignore_result (constants.inject_event event)
+              | _ -> () in
+            Lwt.return ()
+          end
+    )
+  in
+  let state = (v,n,(Sn.succ i), lease_expire_waiters) in
+  Fsm.return ~sides:[con_e;log_e;inject_e] (Stable_master state)
+
 
 let stable_master (type s) constants ((v',n,new_i, lease_expire_waiters) as current_state) ev =
   match ev with
@@ -97,7 +89,6 @@ let stable_master (type s) constants ((v',n,new_i, lease_expire_waiters) as curr
               let log_e = ELog (fun () -> "stable_master: half-lease_expired: update lease." ) in
               let v = Value.create_master_value (me,0L) in
               let ff = fun _ -> Lwt.return () in
-              (* TODO: we need election timeout as well here *)
               Fsm.return ~sides:[log_e] (Master_dictate ([ff], v,n,new_i, lease_expire_waiters))
           in
           match constants.master with
@@ -249,4 +240,5 @@ let master_dictate constants (mo,v,n,i, lease_expire_waiters) () =
        log_e;
       ]
   in
+  start_election_timeout constants n i >>= fun () ->
   Fsm.return ~sides (Accepteds_check_done (mo, n, i, ballot, v, lease_expire_waiters))

--- a/src/paxos/multi_paxos_test.ml
+++ b/src/paxos/multi_paxos_test.ml
@@ -86,6 +86,7 @@ let test_generic network_factory n_nodes () =
               inject_event = inject_ev inject_buffer;
               cluster_id = "whatever";
               quiesced = false;
+              election_timeout = None;
              }
   in
   let all_happy = build_names (n_nodes -1) in
@@ -255,6 +256,7 @@ let test_master_loop network_factory ()  =
                    inject_event = inject_event;
                    cluster_id = "whatever";
                    quiesced = false;
+                   election_timeout = None;
                   } in
   let continue = ref 2 in
   let c0_t () =
@@ -376,6 +378,7 @@ let test_simulation filters () =
     inject_event = inject_event;
     cluster_id = "whatever";
     quiesced = false;
+    election_timeout = None;
   } in
   let c0_t () =
     let expected prev_key key =


### PR DESCRIPTION
refactoring in Master_consensus to reuse an existing code path

CI looks good, but tests took longer to run than expected.
So I've launched them again to see if they finish quicker now... will post an update when these finish.

Might be caused by having all these extra timeout threads now? (But we need them .. or we need another way to schedule these events, maybe also allow cancelling of previous timeout etc...)
Any comments/suggestions more than welcome :)
