### PR TITLE
forced masters should not respond to clients when they're not the master...

### DIFF
--- a/src/node/sync_backend.ml
+++ b/src/node/sync_backend.ml
@@ -382,7 +382,7 @@ struct
             | None -> None,"young cluster"
             | Some (m,ls) ->
               match Node_cfg.get_master cfg with
-                | Elected | Preferred _ ->
+                | Elected | Preferred _ | Forced _ ->
                   begin
                     if (m = my_name ) && (ls < instantiation_time)
                     then None, (Printf.sprintf "%Li considered invalid lease from previous incarnation" ls)
@@ -393,7 +393,6 @@ struct
                         (Some m,"inside lease")
                       else (None,Printf.sprintf "(%Li < (%Li = now) lease expired" ls now)
                   end
-                | Forced x -> Some x,"forced master"
                 | ReadOnly -> Some my_name, "readonly"
 
         in


### PR DESCRIPTION
...,

as this could mean some updates are not yet applied to the store

This fixes a bug where when restarting the forced master it does not yet apply the latest value from it's tlog to the store before it starts responding to client requests. This too eager responding might return outdated data (and resulted in a failure on CI).

Ran it on CI, looks good, except for 1 bug, which I will not solve in this PR.
I have a fix for it already on the branch timeout-accepteds-check-done which should hopefully soon get a PR too (if it doesn't I'll apply the fix on a new separate branch).
