### PR TITLE
stop the fsms in the tests so tests are better separated

### DIFF
--- a/src/main/main.ml
+++ b/src/main/main.ml
@@ -432,7 +432,7 @@ let main () =
           let lease_period = 60 in
           let node = Master_type.Forced "t_arakoon_0" in
           let make_config () = Node_cfg.make_test_config 3 node lease_period in
-          let main_t = (Node_main.test_t make_config !node_id) in
+          let main_t = (Node_main.test_t make_config !node_id (ref false)) in
           Lwt_main.run main_t
         end
   in

--- a/src/system/single.ml
+++ b/src/system/single.ml
@@ -575,6 +575,8 @@ let assert_exists3 tpl =
 
 let _node_name tn n = Printf.sprintf "%s_%i" tn n
 
+let stop = ref false
+
 let setup make_master tn base () =
   _start tn >>= fun () ->
   let lease_period = 10 in
@@ -585,15 +587,17 @@ let setup make_master tn base () =
                          ~node_name:(_node_name tn)
                          3 master lease_period
   in
-  let t0 = Node_main.test_t make_config (_node_name tn 0) >>= fun _ -> Lwt.return () in
-  let t1 = Node_main.test_t make_config (_node_name tn 1) >>= fun _ -> Lwt.return () in
-  let t2 = Node_main.test_t make_config (_node_name tn 2) >>= fun _ -> Lwt.return () in
+  stop := false;
+  let t0 = Node_main.test_t make_config (_node_name tn 0) stop >>= fun _ -> Lwt.return () in
+  let t1 = Node_main.test_t make_config (_node_name tn 1) stop >>= fun _ -> Lwt.return () in
+  let t2 = Node_main.test_t make_config (_node_name tn 2) stop >>= fun _ -> Lwt.return () in
   let all_t = [t0;t1;t2] in
   Lwt.return (tn, make_config (), all_t)
 
 let teardown (tn, _, all_t) =
   Logger.info_f_ "++++++++++++++++++++ %s +++++++++++++++++++" tn >>= fun () ->
-  Lwt.return ()
+  stop := true;
+  Lwt.join all_t
 
 let make_suite base name w =
   let make_el tn b f = tn >:: w tn b f in

--- a/src/system/startup.ml
+++ b/src/system/startup.ml
@@ -104,6 +104,7 @@ let _make_run ~stores ~tlcs ~now ~values ~get_cfgs name () =
     ~name
     ~daemonize:false
     ~catchup_only:false
+    (ref false)
   >>= fun _ -> Lwt.return ()
 
 let _dump_tlc ~tlcs node =


### PR DESCRIPTION
This reduces the git base test output from 71 to 59 MB.
Main benefit is that if/when you have to dig through these logs there won't be the overlap anymore.
