### PR TITLE
prevent mismatch between number of updates and update_results returned f...

### DIFF
--- a/src/node/store.ml
+++ b/src/node/store.ml
@@ -750,7 +750,7 @@ struct
     let prepend_oks n l =
       let rec inner l = function
         | 0 -> l
-        | n -> inner l (n-1) in
+        | n -> inner (Ok None :: l) (n-1) in
       inner l n in
     Lwt.return (prepend_oks j urs)
 


### PR DESCRIPTION
...rom store when inserting a value

Now really prepending the Ok None so it really prevents the mismatch.
