### PR TITLE
Node-to-node TLS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq ocaml libev-dev
+  - sudo apt-get install -qq ocaml libev-dev libssl-dev
 
 install:
   - curl -L https://github.com/OCamlPro/opam/archive/1.0.0.tar.gz | tar xz -C /tmp
@@ -15,7 +15,7 @@ install:
   - eval `opam config -env`
   - opam remote add incubaid-devel -v -y -k git git://github.com/Incubaid/opam-repository-devel.git
   - opam update -v -y
-  - opam install -q -v -y conf-libev lwt camlbz2 camltc
+  - opam install -q -v -y ssl conf-libev lwt camlbz2 camltc
 
 script:
   - eval `opam config -env`

--- a/_tags
+++ b/_tags
@@ -4,6 +4,7 @@ true: warn_error
 true: package(lwt)
 true: package(lwt.preemptive)
 true: package(lwt.unix)
+true: package(lwt.ssl)
 true: package(oUnit)
 true: package(bz2)
 true: package(str)

--- a/cfg/arakoon.ini
+++ b/cfg/arakoon.ini
@@ -34,6 +34,12 @@ cluster_id = ricky
 # only available for clusters of size 1
 # readonly = true
 
+# TLS
+# Path to CA certificate file
+# This will be used to validate certificates provided by other nodes when
+# TLS is used.
+#
+# tls_ca_cert = /path/to/cacert.pem
 
 [default_log_config]
 # available levels are: debug info notice warning error fatal
@@ -65,6 +71,15 @@ batched_transaction_config = default_batched_transaction_config
 # report every x seconds (default = 300)
 #reporting = 10
 
+# TLS
+# SSL/TLS certificate & key to be used by the node
+# Note all nodes in a cluster should be configured to use TLS, mixing is
+# not supported.
+# The certificate should be signed by the CA whose certificate is provided
+# by the "tls_ca_cert" setting in the "global" section.
+#
+# tls_cert = /path/to/arakoon0.pem
+# tls_key = /path/to/arakoon0.key
 
 [arakoon_1]
 ip = 127.0.0.1

--- a/cfg/arakoon.ini
+++ b/cfg/arakoon.ini
@@ -40,6 +40,15 @@ cluster_id = ricky
 # TLS is used.
 #
 # tls_ca_cert = /path/to/cacert.pem
+#
+# Use TLS for client service
+#
+# tls_service = true
+#
+# Require valid certificates from clients (checked using the CA certificate as
+# configured with tls_ca_cert)
+#
+# tls_service_validate_peer = false
 
 [default_log_config]
 # available levels are: debug info notice warning error fatal

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,6 +19,7 @@ Contents:
    arakoon_configuration
    cluster_nodes
    managing_arakoon
+   tls
    nursery
    arakoon_ocaml_client
    arakoon_python_client

--- a/doc/tls.rst
+++ b/doc/tls.rst
@@ -1,0 +1,73 @@
+Using TLS
+=========
+Arakoon can be configured to use TLS connections to communicate with other
+nodes, and (optionally) require clients to use TLS as well.
+
+Setting up PKI infrastructure is outside the scope of this document or the
+Arakoon project, as such we assume a CA is available, and infrastructure is in
+place to generate and distribute keys & signatures, as well as managing CRLs.
+
+In this document, *cacert.pem* will be used as the path of the CA
+certificate and *arakoonN.pem* and *arakoonN.key* (for some N) will be the
+path of node certificates (signed by the CA) & keys.
+
+Configuring inter-node TLS communication
+----------------------------------------
+A cluster of Arakoon nodes can be configured to use TLS for inter-node
+communication. If a cluster uses TLS, this should be configured for *all* nodes
+in the cluster.
+
+To enable node-to-node TLS communication, the following values need to be
+provided in the configuration file:
+
+*global.tls_ca_cert*
+    Path to *cacert.pem*
+
+*arakoonN.tls_cert*
+    Path to *arakoonN.pem*
+
+*arakoonN.tls_key*
+    Path to *arakoonN.key*
+
+In the above, *arakoonN* denotes a per-node configuration section.
+
+When connecting to another node, the node certificate will be requested on both
+sides and validated against the CA certificate. Self-signed certificated
+without a shared CA can't be used.
+
+Configuring client TLS communication
+------------------------------------
+Once inter-node TLS communication is configured and working, nodes can be
+configured to use TLS for client connections as well.
+
+This can be enabled by setting the *global.tls_service* setting to *true*. In
+this configuration, clients will need to connect using TLS, and can (optionally)
+validate the certificate provided by the node it connected to against the CA
+certificate. Nodes can optionally provide a client certificate to the server
+node, but this will not be validated.
+
+If validation of client certificates is desired, the
+*global.tls_service_validate_peer* option can be set to *true*. In this
+configuration, clients connecting to nodes are required to provide a certificate
+upon connection, which will be validated by the node against the CA certificate.
+If a client fails to provide a certificate, or this is not signed by the CA, the
+connection will be rejected.
+
+Using the CLI interface
+-----------------------
+The Arakoon binary provides a CLI interface to connect to clusters and query
+them (e.g. using *--who-master*), perform database operations (*--get*,
+*--set* etc.), or perform administrative operations (e.g. *--drop-master*). When
+nodes are configured to use TLS for client connections as described in
+`Configuring client TLS communication`_, some extra options should be passed on
+the command line.
+
+To use a TLS connection and validate the node certificate against a CA
+certificate (i.e. when *global.tls_service* is set, but
+*global.tls_service_validate_peer* is not), the *-tls-ca-cert* flag should be
+provided, with the path of the CA certificate.
+
+In case a client certificate is required (when
+*global.tls_service_validate_peer* is used), the *-tls-cert* and *-tls-key*
+options should be used, both pointing to the certificate & key files to be used
+when connecting.

--- a/jenkins/base/008_install_dev_env.sh
+++ b/jenkins/base/008_install_dev_env.sh
@@ -8,6 +8,7 @@ eval `opam config env`
 
 opam update -y
 opam pin camltc none || true
+opam install -y ssl
 opam install conf-libev 
 opam install -y camlbz2 
 opam install -y "lwt.2.4.3"

--- a/jenkins/system_tests_quick/005_install_ubuntu_dependencies.sh
+++ b/jenkins/system_tests_quick/005_install_ubuntu_dependencies.sh
@@ -2,6 +2,6 @@
 
 sudo aptitude update || true
 
-for PKG in libssl-dev texlive texlive-latex-extra git python-epydoc graphviz; do
+for PKG in libssl-dev; do
     sudo aptitude install -yVDq $PKG
 done

--- a/jenkins/system_tests_quick/075_test_basic_tls.sh
+++ b/jenkins/system_tests_quick/075_test_basic_tls.sh
@@ -33,6 +33,8 @@ cat > arakoon_tls.ini << EOF
 cluster = arakoon_0, arakoon_1, arakoon_2
 cluster_id = arakoon_tls_test
 tls_ca_cert = $CA_PATH/cacert.pem
+tls_service = true
+tls_service_validate_peer = true
 
 [arakoon_0]
 ip = 127.0.0.1
@@ -62,6 +64,8 @@ tls_cert = $CA_PATH2/arakoon2.pem
 tls_key = $CA_PATH2/arakoon2.key
 EOF
 
+CLIENT_TLS_OPTS="-tls-ca-cert $CA_PATH/cacert.pem -tls-cert $CA_PATH/arakoon2.pem -tls-key $CA_PATH/arakoon2.key"
+
 echo "Test #1: Make sure node listens using TLS & presents cert"
 ./arakoon.native -config arakoon_tls.ini --node arakoon_0 &
 ARAKOON0_PID=$!
@@ -76,7 +80,7 @@ ARAKOON0_PID=$!
 ./arakoon.native -config arakoon_tls.ini --node arakoon_1 &
 ARAKOON1_PID=$!
 sleep 2
-./arakoon.native -config arakoon_tls.ini --who-master
+./arakoon.native -config arakoon_tls.ini $CLIENT_TLS_OPTS --who-master
 kill $ARAKOON0_PID
 kill $ARAKOON1_PID
 sleep 1
@@ -87,19 +91,55 @@ ARAKOON0_PID=$!
 ./arakoon.native -config arakoon_tls.ini --node arakoon_1 &
 ARAKOON1_PID=$!
 sleep 2
-./arakoon.native -config arakoon_tls.ini --who-master
+./arakoon.native -config arakoon_tls.ini $CLIENT_TLS_OPTS --who-master
 kill $ARAKOON1_PID
 sleep 11
-./arakoon.native -config arakoon_tls.ini --who-master 2>&1 | grep "No Master"
+./arakoon.native -config arakoon_tls.ini $CLIENT_TLS_OPTS --who-master 2>&1 | grep "No Master"
 ./arakoon.native -config arakoon_tls.ini --node arakoon_1 &
 ARAKOON1_PID=$!
 sleep 2
-./arakoon.native -config arakoon_tls.ini --who-master
+./arakoon.native -config arakoon_tls.ini $CLIENT_TLS_OPTS --who-master
 kill $ARAKOON0_PID
 kill $ARAKOON1_PID
 sleep 1
 
 echo "Test #4: Make sure certs are validated"
+# Can't use tls_service_validate_peer in this test: client can connect to both
+# nodes, one of them will reject the connection due to certificate mismatch.
+cat > arakoon_tls.ini << EOF
+[global]
+cluster = arakoon_0, arakoon_1, arakoon_2
+cluster_id = arakoon_tls_test
+tls_ca_cert = $CA_PATH/cacert.pem
+
+[arakoon_0]
+ip = 127.0.0.1
+client_port = 4000
+messaging_port = 4010
+home = $NODES_PATH/arakoon_0
+log_level = debug
+tls_cert = $CA_PATH/arakoon0.pem
+tls_key = $CA_PATH/arakoon0.key
+
+[arakoon_1]
+ip = 127.0.0.1
+client_port = 4001
+messaging_port = 4011
+home = $NODES_PATH/arakoon_1
+log_level = debug
+tls_cert = $CA_PATH/arakoon1.pem
+tls_key = $CA_PATH/arakoon1.key
+
+[arakoon_2]
+ip = 127.0.0.1
+client_port = 4002
+messaging_port = 4012
+home = $NODES_PATH/arakoon_2
+log_level = debug
+tls_cert = $CA_PATH2/arakoon2.pem
+tls_key = $CA_PATH2/arakoon2.key
+EOF
+
 ./arakoon.native -config arakoon_tls.ini --node arakoon_0 &
 ARAKOON0_PID=$!
 ./arakoon.native -config arakoon_tls.ini --node arakoon_2 &

--- a/jenkins/system_tests_quick/075_test_basic_tls.sh
+++ b/jenkins/system_tests_quick/075_test_basic_tls.sh
@@ -1,0 +1,111 @@
+#!/bin/bash -xue
+
+WORKDIR=`pwd`
+CA_PATH=`mktemp -d --tmpdir=. --suffix=ca`
+CA_PATH2=`mktemp -d --tmpdir=. --suffix=ca`
+NODES_PATH=`mktemp -d --tmpdir=. --suffix=nodes`
+
+function cleanup {
+    set +e
+    echo "Cleaning up"
+    kill `jobs -p`
+    sleep 1
+    kill -9 `jobs -p`
+    rm -rf $CA_PATH $CA_PATH2 $NODES_PATH arakoon_tls.ini
+}
+
+trap cleanup EXIT
+
+mkdir $NODES_PATH/arakoon_0
+mkdir $NODES_PATH/arakoon_1
+mkdir $NODES_PATH/arakoon_2
+
+pushd $CA_PATH
+$WORKDIR/tools/mkcerts.sh
+popd
+
+pushd $CA_PATH2
+$WORKDIR/tools/mkcerts.sh
+popd
+
+cat > arakoon_tls.ini << EOF
+[global]
+cluster = arakoon_0, arakoon_1, arakoon_2
+cluster_id = arakoon_tls_test
+tls_ca_cert = $CA_PATH/cacert.pem
+
+[arakoon_0]
+ip = 127.0.0.1
+client_port = 4000
+messaging_port = 4010
+home = $NODES_PATH/arakoon_0
+log_level = debug
+tls_cert = $CA_PATH/arakoon0.pem
+tls_key = $CA_PATH/arakoon0.key
+
+[arakoon_1]
+ip = 127.0.0.1
+client_port = 4001
+messaging_port = 4011
+home = $NODES_PATH/arakoon_1
+log_level = debug
+tls_cert = $CA_PATH/arakoon1.pem
+tls_key = $CA_PATH/arakoon1.key
+
+[arakoon_2]
+ip = 127.0.0.1
+client_port = 4002
+messaging_port = 4012
+home = $NODES_PATH/arakoon_2
+log_level = debug
+tls_cert = $CA_PATH2/arakoon2.pem
+tls_key = $CA_PATH2/arakoon2.key
+EOF
+
+echo "Test #1: Make sure node listens using TLS & presents cert"
+./arakoon.native -config arakoon_tls.ini --node arakoon_0 &
+ARAKOON0_PID=$!
+sleep 1
+echo -n "" | openssl s_client -connect localhost:4010 -CAfile $CA_PATH/cacert.pem -cert $CA_PATH/arakoon1.pem -key $CA_PATH/arakoon1.key 2>&1 | grep "Verify return code: 0"
+kill $ARAKOON0_PID
+sleep 1
+
+echo "Test #2: Make sure nodes can communicate"
+./arakoon.native -config arakoon_tls.ini --node arakoon_0 &
+ARAKOON0_PID=$!
+./arakoon.native -config arakoon_tls.ini --node arakoon_1 &
+ARAKOON1_PID=$!
+sleep 2
+./arakoon.native -config arakoon_tls.ini --who-master
+kill $ARAKOON0_PID
+kill $ARAKOON1_PID
+sleep 1
+
+echo "Test #3: Make sure reconnection works"
+./arakoon.native -config arakoon_tls.ini --node arakoon_0 &
+ARAKOON0_PID=$!
+./arakoon.native -config arakoon_tls.ini --node arakoon_1 &
+ARAKOON1_PID=$!
+sleep 2
+./arakoon.native -config arakoon_tls.ini --who-master
+kill $ARAKOON1_PID
+sleep 11
+./arakoon.native -config arakoon_tls.ini --who-master 2>&1 | grep "No Master"
+./arakoon.native -config arakoon_tls.ini --node arakoon_1 &
+ARAKOON1_PID=$!
+sleep 2
+./arakoon.native -config arakoon_tls.ini --who-master
+kill $ARAKOON0_PID
+kill $ARAKOON1_PID
+sleep 1
+
+echo "Test #4: Make sure certs are validated"
+./arakoon.native -config arakoon_tls.ini --node arakoon_0 &
+ARAKOON0_PID=$!
+./arakoon.native -config arakoon_tls.ini --node arakoon_2 &
+ARAKOON2_PID=$!
+sleep 11
+./arakoon.native -config arakoon_tls.ini --who-master 2>&1 | grep "No Master"
+kill $ARAKOON0_PID
+kill $ARAKOON2_PID
+sleep 1

--- a/jenkins/system_tests_slow_left/005_install_ubuntu_dependencies.sh
+++ b/jenkins/system_tests_slow_left/005_install_ubuntu_dependencies.sh
@@ -1,0 +1,1 @@
+../system_tests_quick/005_install_ubuntu_dependencies.sh

--- a/jenkins/system_tests_slow_right/005_install_ubuntu_dependencies.sh
+++ b/jenkins/system_tests_slow_right/005_install_ubuntu_dependencies.sh
@@ -1,0 +1,1 @@
+../system_tests_quick/005_install_ubuntu_dependencies.sh

--- a/jenkins/system_tests_slow_shaky/005_install_ubuntu_dependencies.sh
+++ b/jenkins/system_tests_slow_shaky/005_install_ubuntu_dependencies.sh
@@ -1,0 +1,1 @@
+../system_tests_quick/005_install_ubuntu_dependencies.sh

--- a/src/client/client_main.ml
+++ b/src/client/client_main.ml
@@ -27,16 +27,45 @@ open Lwt
 
 let _address_to_use ips port = make_address (List.hd ips) port
 
-let with_client cfg (cluster:string) f =
-  let sa = _address_to_use cfg.ips cfg.client_port in
+let with_connection ~tls sa do_it = match tls with
+  | None -> Lwt_io.with_connection sa do_it
+  | Some (tls_ca_cert, tls_creds) ->
+    let ctx = Typed_ssl.create_client_context Ssl.TLSv1 in
+    Typed_ssl.set_verify ctx
+      [Ssl.Verify_peer; Ssl.Verify_fail_if_no_peer_cert]
+      (Some Ssl.client_verify_callback);
+    Typed_ssl.load_verify_locations ctx tls_ca_cert "";
+    begin match tls_creds with
+      | None -> ()
+      | Some (cert, key) ->
+          Typed_ssl.use_certificate ctx cert key
+    end;
+    let fd = Lwt_unix.socket (Unix.domain_of_sockaddr sa) Unix.SOCK_STREAM 0 in
+    Lwt_unix.set_close_on_exec fd;
+    Lwt_unix.connect fd sa >>= fun () ->
+    Typed_ssl.Lwt.ssl_connect fd ctx >>= fun (_, sock) ->
+    let ic = Lwt_ssl.in_channel_of_descr sock
+    and oc = Lwt_ssl.out_channel_of_descr sock in
+    Lwt.catch
+      (fun () ->
+        do_it (ic, oc) >>= fun r ->
+        Lwt_ssl.close sock >>= fun () ->
+        Lwt.return r)
+      (fun exc ->
+        Lwt_ssl.close sock >>= fun () ->
+        Lwt.fail exc)
+
+
+let with_client ~tls node_cfg (cluster:string) f =
+  let sa = _address_to_use node_cfg.ips node_cfg.client_port in
   let do_it connection =
     Arakoon_remote_client.make_remote_client cluster connection
     >>= fun (client: Arakoon_client.client) ->
     f client
   in
-  Lwt_io.with_connection sa do_it
+  with_connection ~tls sa do_it
 
-let ping ip port cluster_id =
+let ping ~tls ip port cluster_id =
   let do_it connection =
     let t0 = Unix.gettimeofday () in
     Arakoon_remote_client.make_remote_client cluster_id connection
@@ -47,12 +76,12 @@ let ping ip port cluster_id =
     Lwt_io.printlf "%s\ntook\t%f" s d
   in
   let sa = make_address ip port in
-  let t = Lwt_io.with_connection sa do_it in
+  let t = with_connection ~tls sa do_it in
   Lwt_main.run t; 0
 
 
 
-let find_master cluster_cfg =
+let find_master ~tls cluster_cfg =
   let cfgs = cluster_cfg.cfgs in
   let rec loop = function
     | [] -> Lwt.fail (Failure "too many nodes down")
@@ -63,7 +92,7 @@ let find_master cluster_cfg =
         let sa = _address_to_use cfg.ips cfg.client_port in
         Lwt.catch
           (fun () ->
-             Lwt_io.with_connection sa
+             with_connection ~tls sa
                (fun connection ->
                   Arakoon_remote_client.make_remote_client
                     cluster_cfg.cluster_id connection
@@ -84,49 +113,49 @@ let find_master cluster_cfg =
 
 let run f = Lwt_main.run (f ()); 0
 
-let with_master_client cfg_name f =
+let with_master_client ~tls cfg_name f =
   let ccfg = read_config cfg_name in
   let cfgs = ccfg.cfgs in
-  find_master ccfg >>= fun master_name ->
+  find_master ~tls ccfg >>= fun master_name ->
   let master_cfg = List.hd (List.filter (fun cfg -> cfg.node_name = master_name) cfgs) in
-  with_client master_cfg ccfg.cluster_id f
+  with_client ~tls master_cfg ccfg.cluster_id f
 
-let set cfg_name key value =
-  let t () = with_master_client cfg_name (fun client -> client # set key value)
+let set ~tls cfg_name key value =
+  let t () = with_master_client ~tls cfg_name (fun client -> client # set key value)
   in run t
 
-let get cfg_name key =
+let get ~tls cfg_name key =
   let f (client:Arakoon_client.client) =
     client # get key >>= fun value ->
     Lwt_io.printlf "%S%!" value
   in
-  let t () = with_master_client cfg_name f in
+  let t () = with_master_client ~tls cfg_name f in
   run t
 
 
-let get_key_count cfg_name () =
+let get_key_count ~tls cfg_name () =
   let f (client:Arakoon_client.client) =
     client # get_key_count () >>= fun c64 ->
     Lwt_io.printlf "%Li%!" c64
   in
-  let t () = with_master_client cfg_name f in
+  let t () = with_master_client ~tls cfg_name f in
   run t
 
-let delete cfg_name key =
-  let t () = with_master_client cfg_name (fun client -> client # delete key )
+let delete ~tls cfg_name key =
+  let t () = with_master_client ~tls cfg_name (fun client -> client # delete key )
   in
   run t
 
-let delete_prefix cfg_name prefix =
-  let t () = with_master_client cfg_name (
+let delete_prefix ~tls cfg_name prefix =
+  let t () = with_master_client ~tls cfg_name (
       fun client -> client # delete_prefix prefix >>= fun n_deleted ->
         Lwt_io.printlf "%i" n_deleted
     )
   in
   run t
 
-let prefix cfg_name prefix prefix_size =
-  let t () = with_master_client cfg_name
+let prefix ~tls cfg_name prefix prefix_size =
+  let t () = with_master_client ~tls cfg_name
                (fun client ->
                   client # prefix_keys prefix prefix_size >>= fun keys ->
                   Lwt_list.iter_s (fun k -> Lwt_io.printlf "%S" k ) keys >>= fun () ->
@@ -135,38 +164,38 @@ let prefix cfg_name prefix prefix_size =
   in
   run t
 
-let benchmark cfg_name size tx_size max_n n_clients =
+let benchmark ~tls cfg_name size tx_size max_n n_clients =
   Lwt_io.set_default_buffer_size 32768;
   let t () =
-    let with_c = with_master_client cfg_name in
+    let with_c = with_master_client ~tls cfg_name in
     Benchmark.benchmark ~with_c ~size ~tx_size ~max_n n_clients
   in
   run t
 
 
-let expect_progress_possible cfg_name =
+let expect_progress_possible ~tls cfg_name =
   let f client =
     client # expect_progress_possible () >>= fun b ->
     Lwt_io.printlf "%b" b
   in
-  let t () = with_master_client cfg_name f
+  let t () = with_master_client ~tls cfg_name f
   in
   run t
 
 
-let statistics cfg_name =
+let statistics ~tls cfg_name =
   let f client =
     client # statistics () >>= fun statistics ->
     let rep = Statistics.string_of statistics in
     Lwt_io.printl rep
   in
-  let t () = with_master_client cfg_name f
+  let t () = with_master_client ~tls cfg_name f
   in run t
 
-let who_master cfg_name () =
+let who_master ~tls cfg_name () =
   let cluster_cfg = read_config cfg_name in
   let t () =
-    find_master cluster_cfg >>= fun master_name ->
+    find_master ~tls cluster_cfg >>= fun master_name ->
     Lwt_io.printl master_name
   in
   run t
@@ -185,23 +214,23 @@ let _cluster_and_node_cfg node_name cfg_name =
   let node_cfg = _find cluster_cfg.cfgs in
   cluster_cfg, node_cfg
 
-let node_state node_name cfg_name =
+let node_state ~tls node_name cfg_name =
   let cluster_cfg,node_cfg = _cluster_and_node_cfg node_name cfg_name in
   let cluster = cluster_cfg.cluster_id in
   let f client =
     client # current_state () >>= fun state ->
     Lwt_io.printl state
   in
-  let t () = with_client node_cfg cluster f in
+  let t () = with_client ~tls node_cfg cluster f in
   run t
 
 
 
-let node_version node_name cfg_name =
+let node_version ~tls node_name cfg_name =
   let cluster_cfg, node_cfg = _cluster_and_node_cfg node_name cfg_name in
   let cluster = cluster_cfg.cluster_id in
   let t () =
-    with_client node_cfg cluster
+    with_client ~tls node_cfg cluster
       (fun client ->
          client # version () >>= fun (major,minor,patch, info) ->
          Lwt_io.printlf "%i.%i.%i" major minor patch >>= fun () ->

--- a/src/client/load_client.ml
+++ b/src/client/load_client.ml
@@ -1,8 +1,8 @@
 open Lwt
 
-let load_scenario cfg_name x =
+let load_scenario ~tls cfg_name x =
   let f cn =
-    Client_main.with_master_client
+    Client_main.with_master_client ~tls
       cfg_name
       (fun client ->
          let rec loop i =
@@ -29,4 +29,4 @@ let load_scenario cfg_name x =
   in
   Lwt_list.iter_p f cnis
 
-let main cfg_name n = Lwt_main.run (load_scenario cfg_name n);0
+let main ~tls cfg_name n = Lwt_main.run (load_scenario ~tls cfg_name n);0

--- a/src/client/nodestream_main.ml
+++ b/src/client/nodestream_main.ml
@@ -24,51 +24,51 @@ open Remote_nodestream
 open Lwt
 open Network
 
-let optimize_db ip port cluster_id =
+let optimize_db ~tls ip port cluster_id =
   let do_it connection =
     make_remote_nodestream cluster_id connection >>= fun client ->
     client # optimize_db ()
   in
   let address = make_address ip port in
   let t () =
-    Lwt_io.with_connection address do_it  >>= fun () ->
+    Client_main.with_connection ~tls address do_it  >>= fun () ->
     Lwt.return 0
   in
   Lwt_main.run( t())
 
 
-let defrag_db ip port cluster_id =
+let defrag_db ~tls ip port cluster_id =
   let do_it connection =
     make_remote_nodestream cluster_id connection >>= fun client ->
     client # defrag_db ()
   in
   let address = make_address ip port in
   let t () =
-    Lwt_io.with_connection address do_it >>= fun () ->
+    Client_main.with_connection ~tls address do_it >>= fun () ->
     Lwt.return 0
   in
   Lwt_main.run (t ())
 
-let get_db ip port cluster_id location =
+let get_db ~tls ip port cluster_id location =
   let do_it connection =
     make_remote_nodestream cluster_id connection >>= fun client ->
     client # get_db location
   in
   let address = make_address ip port in
   let t () =
-    Lwt_io.with_connection address do_it  >>= fun () ->
+    Client_main.with_connection ~tls address do_it  >>= fun () ->
     Lwt.return 0
   in
   Lwt_main.run( t())
 
-let drop_master ip port cluster_id =
+let drop_master ~tls ip port cluster_id =
   let do_it connection =
     make_remote_nodestream cluster_id connection >>= fun client ->
     client # drop_master ()
   in
   let address = make_address ip port in
   let t () =
-    Lwt_io.with_connection address do_it >>= fun () ->
+    Client_main.with_connection ~tls address do_it >>= fun () ->
     Lwt.return 0
   in
   Lwt_main.run(t ())

--- a/src/main/main.ml
+++ b/src/main/main.ml
@@ -152,6 +152,9 @@ let run_some_tests repeat_count filter =
 
 
 let main () =
+  Ssl_threads.init ();
+  Ssl.init ~thread_safe:true ();
+
   let _ = Bz2.version in
   let () = Sys.set_signal Sys.sigpipe Sys.Signal_ignore in
   let () = Random.self_init () in

--- a/src/msg/messaging.ml
+++ b/src/msg/messaging.ml
@@ -35,7 +35,8 @@ class type messaging = object
   method expect_reachable: target: id -> bool
   method run :
     ?setup_callback:(unit -> unit Lwt.t) ->
-    ?teardown_callback:(unit -> unit Lwt.t)
-    -> unit -> unit Lwt.t
+    ?teardown_callback:(unit -> unit Lwt.t) ->
+    ?ssl_context:([> `Server ] Typed_ssl.t) ->
+    unit -> unit Lwt.t
   method get_buffer: id -> (Message.t * id) Lwt_buffer.t
 end

--- a/src/node/collapser_main.ml
+++ b/src/node/collapser_main.ml
@@ -23,7 +23,7 @@ If not, see <http://www.gnu.org/licenses/>.
 open Lwt
 
 
-let collapse_remote ip port cluster_id n =
+let collapse_remote ~tls ip port cluster_id n =
   let t () =
     begin
       if n < 1
@@ -38,7 +38,7 @@ let collapse_remote ip port cluster_id n =
       Lwt.return 0
     in
     Lwt.catch
-      (fun () -> Lwt_io.with_connection address collapse)
+      (fun () -> Client_main.with_connection ~tls address collapse)
       (fun exn -> Logger.fatal Logger.Section.main ~exn "remote_collapsing_failed"
         >>= fun () -> Lwt.return (-1)
       )

--- a/src/node/node_cfg.ml
+++ b/src/node/node_cfg.ml
@@ -144,6 +144,8 @@ module Node_cfg = struct
       max_buffer_size: int;
       client_buffer_capacity: int;
       tls_ca_cert: string option;
+      tls_service: bool;
+      tls_service_validate_peer: bool;
     }
 
   let string_of_cluster_cfg cluster_cfg =
@@ -162,12 +164,14 @@ module Node_cfg = struct
       (Printf.sprintf
          ("; _master=%s; _lease_period=%i; cluster_id=%s; plugins=%s; "
           ^^ "overwrite_tlog_entries=%s; max_value_size=%i; max_buffer_size=%i; "
-          ^^ "client_buffer_capacity=%i; tls_ca_cert=%s; }")
+          ^^ "client_buffer_capacity=%i; tls_ca_cert=%s; "
+          ^^ "tls_service=%b; tls_service_validate_peer=%b; }")
          (master2s cluster_cfg._master) cluster_cfg._lease_period cluster_cfg.cluster_id
          (List.fold_left (^) "" cluster_cfg.plugins)
          (Log_extra.int_option2s cluster_cfg.overwrite_tlog_entries)
          cluster_cfg.max_value_size cluster_cfg.max_buffer_size
-         cluster_cfg.client_buffer_capacity (_so2s cluster_cfg.tls_ca_cert));
+         cluster_cfg.client_buffer_capacity (_so2s cluster_cfg.tls_ca_cert)
+         cluster_cfg.tls_service cluster_cfg.tls_service_validate_peer);
     Buffer.contents buffer
 
   let make_test_config
@@ -227,6 +231,8 @@ module Node_cfg = struct
       max_buffer_size = default_max_buffer_size;
       client_buffer_capacity = default_client_buffer_capacity;
       tls_ca_cert = None;
+      tls_service = false;
+      tls_service_validate_peer = false;
     }
     in
     cluster_cfg
@@ -356,6 +362,14 @@ module Node_cfg = struct
   let _tls_ca_cert inifile =
     Ini.get inifile "global" "tls_ca_cert" (Ini.p_option Ini.p_string) (Ini.default None)
 
+  let _tls_service inifile =
+    Ini.get inifile "global" "tls_service"
+      Ini.p_bool (Ini.default false)
+
+  let _tls_service_validate_peer inifile =
+    Ini.get inifile "global" "tls_service_validate_peer"
+      Ini.p_bool (Ini.default false)
+
   let _node_config inifile node_name master =
     let get_string x = Ini.get inifile node_name x Ini.p_string Ini.required in
     let get_bool x = _get_bool inifile node_name x in
@@ -469,6 +483,8 @@ module Node_cfg = struct
     let max_buffer_size = _max_buffer_size inifile in
     let client_buffer_capacity = _client_buffer_capacity inifile in
     let tls_ca_cert = _tls_ca_cert inifile in
+    let tls_service = _tls_service inifile in
+    let tls_service_validate_peer = _tls_service_validate_peer inifile in
     let cluster_cfg =
       { cfgs;
         log_cfgs;
@@ -484,6 +500,8 @@ module Node_cfg = struct
         max_buffer_size;
         client_buffer_capacity;
         tls_ca_cert;
+        tls_service;
+        tls_service_validate_peer;
       }
     in
     cluster_cfg

--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -117,7 +117,7 @@ let _config_batched_transactions node_cfg cluster_cfg =
         with exn -> failwith ("the batched_transaction_config section with name '" ^ btc ^ "' could not be found") in
       set_max btc'.max_entries btc'.max_size
 
-let _config_messaging me others cookie laggy lease_period max_buffer_size =
+let _config_messaging ?ssl_context me others cookie laggy lease_period max_buffer_size =
   let drop_it = match laggy with
     | true -> let count = ref 0 in
       let f msg source target =
@@ -137,8 +137,10 @@ let _config_messaging me others cookie laggy lease_period max_buffer_size =
          a @ acc)
       [] others
   in
+  let client_ssl_context = ssl_context in
   let messaging = new tcp_messaging
-    (me.ips, me.messaging_port) cookie drop_it max_buffer_size ~timeout:(lease_period *. 2.5) in
+    (me.ips, me.messaging_port) cookie drop_it max_buffer_size ~timeout:(lease_period *. 2.5)
+    ?client_ssl_context in
   messaging # register_receivers mapping;
   (messaging :> Messaging.messaging)
 
@@ -225,7 +227,30 @@ let only_catchup (type s) (module S : Store.STORE with type t = s) ~name ~cluste
     (tlc # close)
 
 
+let get_ssl_cert_paths me cluster =
+  match me.tls_cert with
+    | None -> None
+    | Some tls_cert ->
+        match me.tls_key with
+          | None -> failwith "get_ssl_cert_paths: no tls_key"
+          | Some tls_key ->
+              match cluster.tls_ca_cert with
+                | None -> failwith "get_ssl_cert_paths: no tls_ca_cert"
+                | Some tls_ca_cert -> Some (tls_cert, tls_key, tls_ca_cert)
 
+let build_ssl_context me cluster =
+  match get_ssl_cert_paths me cluster with
+    | None -> None
+    | Some (tls_cert, tls_key, tls_ca_cert) ->
+        let ctx = Typed_ssl.create_both_context Ssl.TLSv1 in
+        Typed_ssl.use_certificate ctx tls_cert tls_key;
+        Typed_ssl.set_verify
+          ctx
+          [Ssl.Verify_fail_if_no_peer_cert]
+          (Some Ssl.client_verify_callback);
+        Typed_ssl.set_client_CA_list_from_file ctx tls_ca_cert;
+        Typed_ssl.load_verify_locations ctx tls_ca_cert "";
+        Some ctx
 
 module X = struct
   (* Need to find a name for this:
@@ -330,6 +355,9 @@ let _main_2 (type s)
       in
       Lwt.ignore_result (handle ())) in
   _config_batched_transactions me cluster_cfg;
+
+  let ssl_context = build_ssl_context me cluster_cfg in
+
   if catchup_only
   then
     begin
@@ -422,7 +450,7 @@ let _main_2 (type s)
         end
       in
       Lwt.ignore_result ( upload_cfg_to_keeper () ) ;
-      let messaging  = _config_messaging me cfgs cookie me.is_laggy (float me.lease_period) cluster_cfg.max_buffer_size in
+      let messaging  = _config_messaging ?ssl_context me cfgs cookie me.is_laggy (float me.lease_period) cluster_cfg.max_buffer_size in
       Logger.info_f_ "cfg = %s" (string_of me) >>= fun () ->
       Lwt_list.iter_s (fun m -> Logger.info_f_ "other: %s" m)
         other_names >>= fun () ->
@@ -616,7 +644,7 @@ let _main_2 (type s)
            let msg_t =
              log_exception
                "Exception in messaging thread"
-               (fun () -> Lwt_mutex.with_lock msg_mutex (messaging # run)) in
+               (fun () -> Lwt_mutex.with_lock msg_mutex (messaging # run ?ssl_context)) in
            Lwt.finalize
              (fun () ->
                 Lwt.choose

--- a/src/system/startup.ml
+++ b/src/system/startup.ml
@@ -70,6 +70,8 @@ let _make_cfg name n lease_period =
     fsync = false;
     is_test = true;
     reporting = 300;
+    tls_cert = None;
+    tls_key = None;
   }
 
 let _make_tlog_coll tlcs values tlc_name tlf_dir head_dir use_compression fsync node_id =
@@ -141,6 +143,7 @@ let post_failure () =
     max_value_size = Node_cfg.default_max_value_size;
     max_buffer_size = Node_cfg.default_max_buffer_size;
     client_buffer_capacity = Node_cfg.default_client_buffer_capacity;
+    tls_ca_cert = None;
   }
   in
   let get_cfgs () = cluster_cfg in
@@ -197,7 +200,8 @@ let restart_slaves () =
      overwrite_tlog_entries = None;
      max_value_size = Node_cfg.default_max_value_size;
      max_buffer_size = Node_cfg.default_max_buffer_size;
-     client_buffer_capacity = Node_cfg.default_client_buffer_capacity
+     client_buffer_capacity = Node_cfg.default_client_buffer_capacity;
+     tls_ca_cert = None;
     }
   in
   let get_cfgs () = cluster_cfg in

--- a/src/system/startup.ml
+++ b/src/system/startup.ml
@@ -144,6 +144,8 @@ let post_failure () =
     max_buffer_size = Node_cfg.default_max_buffer_size;
     client_buffer_capacity = Node_cfg.default_client_buffer_capacity;
     tls_ca_cert = None;
+    tls_service = false;
+    tls_service_validate_peer = false;
   }
   in
   let get_cfgs () = cluster_cfg in
@@ -202,6 +204,8 @@ let restart_slaves () =
      max_buffer_size = Node_cfg.default_max_buffer_size;
      client_buffer_capacity = Node_cfg.default_client_buffer_capacity;
      tls_ca_cert = None;
+     tls_service = false;
+     tls_service_validate_peer = false;
     }
   in
   let get_cfgs () = cluster_cfg in

--- a/src/tools/server.ml
+++ b/src/tools/server.ml
@@ -32,6 +32,12 @@ let no_callback = Lwt.return
 
 exception FOOBAR
 
+type socket = Plain of Lwt_unix.file_descr
+            | TLS of Lwt_ssl.socket
+
+let close = function
+  | Plain fd -> Lwt_unix.close fd
+  | TLS fd -> Lwt_ssl.close fd
 
 let deny (ic,oc,cid) =
   Logger.warning_ "max connections reached, denying this one" >>= fun () ->
@@ -42,8 +48,15 @@ let deny (ic,oc,cid) =
 let session_thread (sid:string) cid protocol fd =
   Lwt.catch
     (fun () ->
-       let ic = Lwt_io.of_fd ~mode:Lwt_io.input fd
-       and oc = Lwt_io.of_fd ~mode:Lwt_io.output fd
+       let (ic, oc) = match fd with
+         | Plain fd' ->
+             let ic = Lwt_io.of_fd ~mode:Lwt_io.input fd'
+             and oc = Lwt_io.of_fd ~mode:Lwt_io.output fd' in
+             (ic, oc)
+         | TLS fd' ->
+             let ic = Lwt_ssl.in_channel_of_descr fd'
+             and oc = Lwt_ssl.out_channel_of_descr fd' in
+             (ic, oc)
        in protocol (ic,oc,cid)
     )
     (function
@@ -56,7 +69,7 @@ let session_thread (sid:string) cid protocol fd =
         Logger.info_f_ ~exn "exiting session (%s) connection=%s" sid cid)
   >>= fun () ->
   Lwt.catch
-    ( fun () -> Lwt_unix.close fd )
+    ( fun () -> close fd )
     ( function
       | Canceled -> Lwt.fail Canceled
       | exn -> Logger.info_f_ ~exn "Exception on closing of socket (connection=%s)" cid)
@@ -88,6 +101,7 @@ let make_server_thread
       ?(name = "socket server")
       ?(setup_callback=no_callback)
       ?(teardown_callback = no_callback)
+      ?(ssl_context : [> `Server ] Typed_ssl.t option)
       ~scheme
       host port protocol =
   let new_socket () = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
@@ -97,6 +111,12 @@ let make_server_thread
     Lwt_unix.setsockopt listening_socket Unix.SO_REUSEADDR true;
     Lwt_unix.bind listening_socket socket_address;
     Lwt_unix.listen listening_socket 1024;
+    let () = match ssl_context with
+      | None -> ()
+      | Some ctx ->
+          let _ = Typed_ssl.embed_socket (Lwt_unix.unix_file_descr listening_socket) in
+          ()
+    in
     let maybe_take,release = scheme in
     let connection_counter = make_counter () in
     let client_threads = Hashtbl.create 10 in
@@ -104,20 +124,39 @@ let make_server_thread
     let rec server_loop () =
       Lwt.catch
         (fun () ->
-           Lwt_unix.accept listening_socket >>= fun (fd, cl_socket_address) ->
+           Lwt_unix.accept listening_socket >>= fun (plain_fd, cl_socket_address) ->
+           begin match ssl_context with
+             | None -> Lwt.return (Plain plain_fd)
+             | Some ctx ->
+                 Lwt.catch
+                   (fun () ->
+                     Typed_ssl.Lwt.ssl_accept plain_fd ctx >>= fun (s, lwt_s) ->
+                     let cert = Ssl.get_certificate s in
+                     Logger.info_f_
+                       "server_loop: Received SSL connection, subject=%s"
+                       (Ssl.get_subject cert) >>= fun () ->
+                     let cipher = Ssl.get_cipher s in
+                     Logger.debug_f_
+                       "server_loop: SSL connection using %s"
+                       (Ssl.get_cipher_description cipher) >>= fun () ->
+                     Lwt.return (TLS lwt_s))
+                   (fun exn ->
+                     Lwt_unix.close plain_fd >>= fun () ->
+                     Lwt.fail exn)
+           end >>= fun sock ->
            let cid = name ^ "_" ^ Int64.to_string (connection_counter ()) in
            let client_thread () =
              match maybe_take () with
                | None ->
-                 session_thread "--" cid deny fd
+                 session_thread "--" cid deny sock
                | Some id ->
-                 Lwt_unix.fstat fd >>= fun fstat ->
+                 Lwt_unix.fstat plain_fd >>= fun fstat ->
                  Logger.info_f_
                    "%s:session=%i connection=%s socket_address=%s file_descriptor_inode=%i"
                    name id cid (socket_address_to_string cl_socket_address) fstat.Lwt_unix.st_ino
                  >>= fun () ->
                  let sid = string_of_int id in
-                 session_thread sid cid protocol fd >>= fun () ->
+                 session_thread sid cid protocol sock >>= fun () ->
                  release();
                  Lwt.return()
            in
@@ -125,14 +164,14 @@ let make_server_thread
            Lwt.ignore_result
              (Lwt.finalize
                 (fun () ->
-                   Hashtbl.add client_threads cid (t, fd);
+                   Hashtbl.add client_threads cid (t, sock);
                    Lwt.catch
                      (fun () -> t)
                      (fun exn ->
                         Logger.info_f_ ~exn "Exception in client thread %s" cid))
                 (fun () ->
                    Lwt.catch
-                     (fun () -> Lwt_unix.close fd)
+                     (fun () -> close sock)
                      (fun exn ->
                         let level = match exn with
                           | Unix.Unix_error(Unix.EBADF, _, _) -> Logger.Debug
@@ -156,6 +195,11 @@ let make_server_thread
               s0 s1 port timeout >>= fun () ->
             Lwt_unix.sleep timeout >>= fun () ->
             server_loop ()
+          | Ssl.Accept_error _ as exn ->
+              Logger.warning_f_ ~exn
+                "Ssl.Accept_error in server_loop: %s"
+                (Ssl.get_error_string ()) >>=
+              server_loop
           | e -> Lwt.fail e
         )
     in
@@ -179,7 +223,7 @@ let make_server_thread
                 Logger.info_f_ "closing client thread fd %s" k >>= fun () ->
                 Lwt.catch
                   (fun () ->
-                     Lwt_unix.close fd >>= fun () ->
+                     close fd >>= fun () ->
                      Logger.info_f_ "closed client thread fd %s" k)
                   (fun exn ->
                      Logger.info_f_ ~exn "exception while closing fd %s" k))

--- a/src/tools/typed_ssl.ml
+++ b/src/tools/typed_ssl.ml
@@ -1,0 +1,17 @@
+type 'a t = Ssl.context
+
+let create_client_context proto = Ssl.create_context proto Ssl.Client_context
+let create_server_context proto = Ssl.create_context proto Ssl.Server_context
+let create_both_context proto = Ssl.create_context proto Ssl.Both_context
+
+open Lwt
+
+module Lwt = struct
+  let ssl_connect fd ctx =
+    Lwt_ssl.ssl_connect fd ctx >>= fun lwt_s ->
+    match Lwt_ssl.ssl_socket lwt_s with
+      | None -> Lwt.fail (Failure "Typed_ssl.Lwt.ssl_connect: unexpected plain socket")
+      | Some s -> Lwt.return (s, lwt_s)
+
+  let ssl_accept = Lwt_ssl.ssl_accept
+end

--- a/src/tools/typed_ssl.ml
+++ b/src/tools/typed_ssl.ml
@@ -4,6 +4,13 @@ let create_client_context proto = Ssl.create_context proto Ssl.Client_context
 let create_server_context proto = Ssl.create_context proto Ssl.Server_context
 let create_both_context proto = Ssl.create_context proto Ssl.Both_context
 
+let embed_socket = Ssl.embed_socket
+
+let use_certificate = Ssl.use_certificate
+let set_verify = Ssl.set_verify
+let set_client_CA_list_from_file = Ssl.set_client_CA_list_from_file
+let load_verify_locations = Ssl.load_verify_locations
+
 open Lwt
 
 module Lwt = struct
@@ -13,5 +20,9 @@ module Lwt = struct
       | None -> Lwt.fail (Failure "Typed_ssl.Lwt.ssl_connect: unexpected plain socket")
       | Some s -> Lwt.return (s, lwt_s)
 
-  let ssl_accept = Lwt_ssl.ssl_accept
+  let ssl_accept fd ctx =
+    Lwt_ssl.ssl_accept fd ctx >>= fun lwt_s ->
+    match Lwt_ssl.ssl_socket lwt_s with
+      | None -> Lwt.fail (Failure "Typed_ssl.Lwt.ssl_accept: unexpected plain socket")
+      | Some s -> Lwt.return (s, lwt_s)
 end

--- a/src/tools/typed_ssl.mli
+++ b/src/tools/typed_ssl.mli
@@ -4,6 +4,14 @@ val create_client_context : Ssl.protocol -> [ `Client ] t
 val create_server_context : Ssl.protocol -> [ `Server ] t
 val create_both_context : Ssl.protocol -> [ `Client | `Server ] t
 
+val embed_socket : Unix.file_descr -> 'a t -> Ssl.socket
+
+val use_certificate : 'a t -> string -> string -> unit
+val set_verify : 'a t -> Ssl.verify_mode list -> Ssl.verify_callback option -> unit
+val set_client_CA_list_from_file : [> `Server ] t -> string -> unit
+val load_verify_locations : 'a t -> string -> string -> unit
+
 module Lwt : sig
   val ssl_connect : Lwt_unix.file_descr -> [> `Client ] t -> (Ssl.socket * Lwt_ssl.socket) Lwt.t
+  val ssl_accept : Lwt_unix.file_descr -> [> `Server ] t -> (Ssl.socket * Lwt_ssl.socket) Lwt.t
 end

--- a/src/tools/typed_ssl.mli
+++ b/src/tools/typed_ssl.mli
@@ -1,0 +1,9 @@
+type 'a t
+
+val create_client_context : Ssl.protocol -> [ `Client ] t
+val create_server_context : Ssl.protocol -> [ `Server ] t
+val create_both_context : Ssl.protocol -> [ `Client | `Server ] t
+
+module Lwt : sig
+  val ssl_connect : Lwt_unix.file_descr -> [> `Client ] t -> (Ssl.socket * Lwt_ssl.socket) Lwt.t
+end

--- a/tools/mkcerts.sh
+++ b/tools/mkcerts.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -ue
+
+echo "Warning"
+echo "======="
+echo "This utility script should not be used to generate certificates"
+echo "for a real production setup. It should be considered insecure"
+echo "and has not been audited."
+echo
+
+run () {
+    local oifs=$IFS
+    local msg=$1
+    shift
+    echo "$msg:"
+    IFS=" "
+    echo "> $*"
+    echo
+    IFS=""
+    $*
+    echo
+    IFS=$oifs
+}
+
+run "Creating CA key & CSR" \
+    openssl req -new -nodes -out cacert-req.pem -keyout cacert.key -subj '/C=BE/ST=Oost-Vlaanderen/L=Lochristi/O=Incubaid BVBA/OU=Arakoon Testing/CN=Arakoon Testing CA'
+
+run "Self-signing CA CSR" \
+    openssl x509 -signkey cacert.key -req -in cacert-req.pem -out cacert.pem
+run "Removing CA CSR" \
+    rm cacert-req.pem
+
+for i in `seq 0 2`; do
+    run "Creating key and CSR for arakoon$i" \
+        openssl req -out arakoon$i-req.pem -new -nodes -keyout arakoon$i.key -subj "/C=BE/ST=Oost-Vlaanderen/L=Lochristi/O=Incubaid BVBA/OU=Arakoon Testing/CN=arakoon$i"
+    run "Signing CSR for arakoon$i" \
+        openssl x509 -req -in arakoon$i-req.pem -CA cacert.pem -CAkey cacert.key -out arakoon$i.pem -set_serial 0$i
+    run "Removing CSR for arakoon$i" \
+        rm arakoon$i-req.pem
+    run "Verifying certificate" \
+        openssl verify -CAfile cacert.pem arakoon$i.pem
+done


### PR DESCRIPTION
These changes add (optional) node-to-node TLS encryption & authentication using certificates.

Some TODOs left, but what's here should be OK for review.

CI running without actually _using_ TLS (i.e. no configuration, using plain sockets only), base & quick passed.

TODO:
- [x] Add `mkcerts.sh` script for CI purposes
- [x] Add simple testcase to validate nodes use TLS when configured to, e.g. using `echo -n "" | openssl s_client -connect localhost:4010 -CAfile ca/cacert.pem -cert ca/arakoon1.pem -key ca/arakoon1.key 2>&1 | grep "Verify return code"`
- [ ] Add more elaborate testcases for reconnecting behavior etc (re-use system tests)
