### PR TITLE
fix StoreCounterTooLow for forced slaves

### DIFF
--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -462,7 +462,11 @@ let _main_2 (type s)
             then
               begin
                 S.quiesce store >>= fun () ->
-                S._set_i store (Sn.pred last_i);
+                if last_i <> 0L
+                then (* this is an optimization so catchup doesn't need to pretend
+                        to apply all previous values from tlog to the store
+                        if last_i = 0 this would result in an invalid store counter -1 *)
+                  S._set_i store (Sn.pred last_i);
                 Lwt.return ()
               end
             else


### PR DESCRIPTION
I couldn't help myself and had another quick look at CI and noticed the QUICK suite failing a bit too much for my liking.
Apparently I have introduced a bug with my latest merges (not sure how/why I missed it).
This pull request should fix that.
CI tests are still running, but the quick suite that was now consistently failing already passed again, so things should probably be good again.
