### PR TITLE
PyLabs: Don't ignore 'inject-as-head' exit code

### DIFF
--- a/extension/server/ArakoonManagement.py
+++ b/extension/server/ArakoonManagement.py
@@ -1030,8 +1030,9 @@ class ArakoonCluster:
         rs = ' '.join(r)
         p = subprocess.Popen(rs, shell= True, stdout = subprocess.PIPE)
         output = p.communicate()[0]
-        logging.debug("injectAsHead returned %s", output)
-        return
+        rc = p.returncode
+        logging.debug("injectAsHead returned [%d] %s", rc, output)
+        return rc
         
         
     def defragDb(self, nodeName):


### PR DESCRIPTION
Related to mail-conversations with Wouter.

CI passed for -shaky (at least the 2 changed tests, others still running), which is the only impacted testsuite:

```
test_inject_as_head : asserts shortcut for those who don't want to collapse periodically. (eta: 20 s) ... ok
Test inject_as_head with a fake database file (should fail) ... Fatal error: exception Failure("read error")
ok
```

Notice this goes into 1.6 (will forward-merge to 1.7 afterwards).
