### PR TITLE
increasing counter in election_suggest loop which decreases respect for ...

### DIFF
--- a/extension/test/server/right/system_tests_preferred_masters.py
+++ b/extension/test/server/right/system_tests_preferred_masters.py
@@ -26,7 +26,7 @@ import time
 import logging
 
 @Common.with_custom_setup(Common.setup_3_nodes, Common.basic_teardown)
-def test_prefered_master():
+def test_preferred_master():
     cluster = Common.q.manage.arakoon.getCluster(Common.cluster_id)
     cluster.stop()
     pm = Common.node_names[0]
@@ -62,7 +62,7 @@ def test_prefered_master():
 
 
 @Common.with_custom_setup(lambda h: Common.setup_n_nodes(5, False, h), Common.basic_teardown)
-def test_prefered_masters():
+def test_preferred_masters():
     # Get reference to the cluster
     cluster = Common.q.manage.arakoon.getCluster(Common.cluster_id)
     cluster.stop()

--- a/src/paxos/multi_paxos_type.ml
+++ b/src/paxos/multi_paxos_type.ml
@@ -38,7 +38,7 @@ type transitions =
   | Forced_master_suggest of (n * i)
 
   (* election only *)
-  | Election_suggest of (n)
+  | Election_suggest of (n * int)
 
   (* slave or pending slave *)
   | Slave_fake_prepare of (n * i)
@@ -51,11 +51,11 @@ type transitions =
                               Messaging.id list *
                               v_limits *
                               (string * Mp_msg.MPMessage.n) option *
-                              slave_awaiters)
+                              slave_awaiters * int)
   | Wait_for_promises of (n * i * Messaging.id list *
                             v_limits *
                             (string * Mp_msg.MPMessage.n) option *
-                            slave_awaiters)
+                            slave_awaiters * int)
   | Accepteds_check_done of (master_option * n * i *
                                (int * Messaging.id list) * Value.t *
                                slave_awaiters)

--- a/src/paxos/slave.ml
+++ b/src/paxos/slave.ml
@@ -93,7 +93,7 @@ let slave_steady_state (type s) constants state event =
         begin
           let log_e = ELog (fun () -> "slave_steady_state: Elections needed") in
           let new_n = update_n constants n in
-          Fsm.return ~sides:[log_e] (Election_suggest (new_n))
+          Fsm.return ~sides:[log_e] (Election_suggest (new_n, 0))
         end
       else
         begin
@@ -285,7 +285,7 @@ let slave_discovered_other_master (type s) constants state () =
           (* we have to go to election here or we can get in a situation where
              everybody just waits for each other *)
           let new_n = update_n constants future_n in
-          (Election_suggest (new_n)),
+          (Election_suggest (new_n, 0)),
           "slave_discovered_other_master: my i is bigger then theirs ; back to election"
         else
           begin


### PR DESCRIPTION
...preferred masters

This change makes the master election for election=Preferred converge to the behavior of normal master election.
This should prevent non preferred nodes from going into an ever increasing n election_suggest loop
