### PR TITLE
sane defaults for batched store

### DIFF
--- a/cfg/arakoon.ini
+++ b/cfg/arakoon.ini
@@ -43,8 +43,8 @@ tcp_messaging = debug
 
 
 [default_batched_transaction_config]
-max_entries = 10000    # number of sets and deletes
-max_size    = 10000000 # in bytes
+max_entries = 100    # number of sets and deletes
+max_size    = 100000 # in bytes
 
 
 [arakoon_0]

--- a/src/node/batched_store.ml
+++ b/src/node/batched_store.ml
@@ -33,7 +33,7 @@ sig
   val _tranabort : t -> unit
 end
 
-let default_max_entries = 200
+let default_max_entries = 100
 let default_max_size = 100_000
 
 let max_entries = ref default_max_entries

--- a/src/node/local_store.ml
+++ b/src/node/local_store.ml
@@ -119,7 +119,9 @@ let _trancommit ls =
         let t = ( Unix.gettimeofday() -. t0) in
         if t > 1.0
         then
-          Lwt.ignore_result ( Logger.info_f_ "Tokyo cabinet transaction took %fs" t )
+          let fn = Camltc.Hotc.filename ls.db in
+          Lwt.ignore_result
+            ( Logger.info_f_ "Tokyo cabinet (%s) transaction took %fs" fn t )
 
 
 let _tranabort ls =
@@ -143,7 +145,8 @@ let with_transaction ls f =
       let t = ( Unix.gettimeofday() -. t0) in
       if t > 1.0
       then
-        Logger.info_f_ "Tokyo cabinet transaction took %fs" t
+        let fn = Camltc.Hotc.filename ls.db in
+        Logger.info_f_ "Tokyo cabinet (%s) transaction took %fs" fn t
       else
         Lwt.return (); >>= fun () ->
       ls._tx <- None; Lwt.return ())

--- a/src/tlog/compression.ml
+++ b/src/tlog/compression.ml
@@ -23,8 +23,8 @@ If not, see <http://www.gnu.org/licenses/>.
 open Lwt
 open Tlogcommon
 
-let archive_name tlog_name = tlog_name ^ ".aar" 
-let tlog_name archive_name = 
+let archive_name tlog_name = tlog_name ^ ".aar"
+let tlog_name archive_name =
   let len = String.length archive_name in
   let ext = String.sub archive_name (len-4) 4 in
   assert (ext=".aar");
@@ -32,39 +32,39 @@ let tlog_name archive_name =
 
 
 let compress_tlog ?(cancel=(ref false)) tlog_name archive_name =
-  let limit = 8 * 1024 * 1024 (* 896 * 1024  *)in
+  let limit = 2 * 1024 * 1024 (* 896 * 1024  *)in
   let buffer_size = limit + (64 * 1024) in
-  Lwt_io.with_file ~mode:Lwt_io.input tlog_name 
+  Lwt_io.with_file ~mode:Lwt_io.input tlog_name
     (fun ic ->
       Lwt_io.with_file ~mode:Lwt_io.output archive_name
-	    (fun oc ->  
-	      let rec fill_buffer (buffer:Buffer.t) (last_i:Sn.t) (counter:int) = 
-	        Lwt.catch
-	          (fun () -> 
-		        Tlogcommon.read_entry ic >>= fun (entry:Entry.t) ->
-                let i = Entry.i_of entry 
-                and v = Entry.v_of entry 
+        (fun oc ->
+          let rec fill_buffer (buffer:Buffer.t) (last_i:Sn.t) (counter:int) =
+            Lwt.catch
+              (fun () ->
+                Tlogcommon.read_entry ic >>= fun (entry:Entry.t) ->
+                let i = Entry.i_of entry
+                and v = Entry.v_of entry
                 in
-		        Tlogcommon.entry_to buffer i v;
-		        let (last_i':Sn.t) = if i > last_i then i else last_i in
-		        if Buffer.length buffer < limit || counter = 0
-		        then fill_buffer (buffer:Buffer.t) last_i' (counter+1)
-		        else Lwt.return (last_i',counter)
-	          )
-	          (function 
-		        | End_of_file -> Lwt.return (last_i,counter)
-		        | exn -> Lwt.fail exn
-	          )
-	      in
-	      let compress_and_write last_i buffer = 
-	        let contents = Buffer.contents buffer in
-	        let t0 = Unix.gettimeofday () in
-	        Lwt_preemptive.detach 
-	          (fun () ->
-		        let output = Bz2.compress ~block:9 contents 0 (String.length contents) 
-		        in
-		        output) () 
-	        >>= fun output ->
+                Tlogcommon.entry_to buffer i v;
+                let (last_i':Sn.t) = if i > last_i then i else last_i in
+                if Buffer.length buffer < limit || counter = 0
+                then fill_buffer (buffer:Buffer.t) last_i' (counter+1)
+                else Lwt.return (last_i',counter))
+              (function
+              | End_of_file -> Lwt.return (last_i,counter)
+              | exn -> Lwt.fail exn
+              )
+          in
+          let compress_and_write last_i buffer =
+            let contents = Buffer.contents buffer in
+            let t0 = Unix.gettimeofday () in
+            Lwt_preemptive.detach
+              (fun () ->
+                let output = Bz2.compress ~block:9 contents 0
+                  (String.length contents)
+                in
+                output) ()
+            >>= fun output ->
             begin
               if !cancel
               then
@@ -73,59 +73,58 @@ let compress_tlog ?(cancel=(ref false)) tlog_name archive_name =
                 Lwt.return ()
             end >>= fun () ->
             let t1 = Unix.gettimeofday() in
-	        let d = t1 -. t0 in
+            let d = t1 -. t0 in
             let cl = String.length contents in
-            let ol = String.length output in 
+            let ol = String.length output in
             let factor = (float cl) /. (float ol) in
-	        Logger.debug_f Logger.Section.main "compression: %i bytes into %i (in %f s) (factor=%2f)" cl ol d factor 
-	        >>= fun () ->
-	        Llio.output_int64 oc last_i >>= fun () ->
-	        Llio.output_string oc output >>= fun () ->
+            Logger.debug_f Logger.Section.main "compression: %i bytes into %i (in %f s) (factor=%2f)" cl ol d factor
+            >>= fun () ->
+            Llio.output_int64 oc last_i >>= fun () ->
+            Llio.output_string oc output >>= fun () ->
             let sleep = 2.0 *. d in
             Logger.debug_f Logger.Section.main "compression: sleeping %f" sleep >>= fun () ->
             Lwt_unix.sleep sleep
-	      in
-	      let buffer = Buffer.create buffer_size in
-	      let rec loop () = 
-	        fill_buffer buffer (-1L) 0 >>= fun (last_i,counter) ->
-	        if counter = 0 
-	        then Lwt.return ()
-	        else
-	          begin
-		        compress_and_write last_i buffer >>= fun () ->
-		        let () = Buffer.clear buffer in
-		        loop ()
-	          end
-	      in
-	      loop ()
-	    )
+          in
+          let buffer = Buffer.create buffer_size in
+          let rec loop () =
+            fill_buffer buffer (-1L) 0 >>= fun (last_i,counter) ->
+            if counter = 0
+            then Lwt.return ()
+            else
+              begin
+                compress_and_write last_i buffer >>= fun () ->
+                let () = Buffer.clear buffer in
+                loop ()
+              end
+          in
+          loop ()
+        )
     )
-    
-let uncompress_tlog archive_name tlog_name = 
+
+let uncompress_tlog archive_name tlog_name =
   Lwt_io.with_file ~mode:Lwt_io.input archive_name
     (fun ic ->
       Lwt_io.with_file ~mode:Lwt_io.output tlog_name
-	    (fun oc ->
-	      let rec loop () = 
-	        Lwt.catch
-		      (fun () -> 
-		        Sn.input_sn ic >>= fun last_i ->
-		        Llio.input_string ic >>= fun compressed -> 
-		        Lwt.return (Some compressed))
-		      (function 
-		        | End_of_file -> Lwt.return None
-		        | exn -> Lwt.fail exn
-		      )
-	        >>= function 
-		      | None -> Lwt.return () 
-		      | Some compressed ->
-		        begin
-		          let lc = String.length compressed in
-		          let output = Bz2.uncompress compressed 0 lc in
-		          let lo = String.length output in
-		          Lwt_io.write_from_exactly oc output 0 lo >>= fun () ->
-		          loop ()
-		        end
-	      in loop ())
+        (fun oc ->
+          let rec loop () =
+            Lwt.catch
+              (fun () ->
+                Sn.input_sn ic >>= fun last_i ->
+                Llio.input_string ic >>= fun compressed ->
+                Lwt.return (Some compressed))
+              (function
+              | End_of_file -> Lwt.return None
+              | exn -> Lwt.fail exn
+              )
+            >>= function
+            | None -> Lwt.return ()
+            | Some compressed ->
+              begin
+                let lc = String.length compressed in
+                let output = Bz2.uncompress compressed 0 lc in
+                let lo = String.length output in
+                Lwt_io.write_from_exactly oc output 0 lo >>= fun () ->
+                loop ()
+              end
+          in loop ())
     )
-    


### PR DESCRIPTION
same defaults in example cfg
compression on 2MB iso 8MB
log which tokyo cabinet is slow
