### PR TITLE
Backport forced master

### DIFF
--- a/extension/test/server/right/system_tests_long_right.py
+++ b/extension/test/server/right/system_tests_long_right.py
@@ -81,7 +81,7 @@ def test_expect_progress_fixed_master ():
     except:
         pass
     Common.restart_all()
-    time.sleep(1.0)
+    cli.set('','')
     assert_true( cli.expectProgressPossible(),
                  "Master store counter is ahead of slave" )
 

--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -470,7 +470,7 @@ let _main_2 (type s)
               tlog_coll # close () >>= fun () ->
               Lwt.fail ex)
 	      >>= fun (new_i, vo) ->
-
+              S.clear_self_master store me.node_name;
 	      let client_buffer =
 	        let capacity = Some (cluster_cfg.client_buffer_capacity) in
 	        Lwt_buffer.create ~capacity () in

--- a/src/node/store.ml
+++ b/src/node/store.ml
@@ -122,7 +122,6 @@ module type STORE =
     val safe_insert_value : t -> Sn.t -> Value.t -> update_result list Lwt.t
     val with_transaction : t -> (transaction -> 'a Lwt.t) -> 'a Lwt.t
     val relocate : t -> string -> unit Lwt.t
-    val who_master : t -> (string * int64) option
 
     val quiesced : t -> bool
     val quiesce : t -> unit Lwt.t
@@ -136,8 +135,11 @@ module type STORE =
     val get_catchup_start_i : t -> int64
 
     val incr_i : t -> unit Lwt.t
-    val set_master_no_inc : t -> string -> int64 -> unit Lwt.t
+
     val set_master : t -> transaction -> string -> int64 -> unit Lwt.t
+    val set_master_no_inc : t -> string -> int64 -> unit Lwt.t
+    val clear_self_master : t -> string -> unit
+    val who_master : t -> (string * int64) option
 
     val get : t -> string -> string Lwt.t
     val exists : t -> string -> bool Lwt.t
@@ -333,6 +335,11 @@ struct
       end
     else
       S.with_transaction store.s (fun tx -> set_master store tx master lease_start)
+
+  let clear_self_master store me =
+    match store.master with
+      | Some (m, ls) when m = me -> store.master <- None
+      | _ -> ()
 
   let who_master store =
     store.master

--- a/src/node/sync_backend.ml
+++ b/src/node/sync_backend.ml
@@ -382,7 +382,7 @@ object(self: #backend)
 	| None -> None,"young cluster"
 	| Some (m,ls) ->
 	  match Node_cfg.get_master cfg with
-	    | Elected | Preferred _ ->
+	    | Elected | Preferred _ | Forced _ ->
 	      begin
 	      if (m = my_name ) && (ls < instantiation_time)
 	      then None, (Printf.sprintf "%Li considered invalid lease from previous incarnation" ls)
@@ -393,7 +393,6 @@ object(self: #backend)
 		  (Some m,"inside lease")
 		else (None,Printf.sprintf "(%Li < (%Li = now) lease expired" ls now)
 	      end
-	    | Forced x -> Some x,"forced master"
 	    | ReadOnly -> Some my_name, "readonly"
 
     in

--- a/src/node/sync_backend.ml
+++ b/src/node/sync_backend.ml
@@ -121,7 +121,6 @@ class sync_backend = fun cfg
 				    "value too large"))
   in
 object(self: #backend)
-  val instantiation_time = Int64.of_float (Unix.time())
   val witnessed = Hashtbl.create 10
   val _stats = Statistics.create ()
   val mutable client_cfgs = None
@@ -379,21 +378,18 @@ object(self: #backend)
     let mo = self # _who_master () in
     let result,argumentation =
       match mo with
-	| None -> None,"young cluster"
-	| Some (m,ls) ->
-	  match Node_cfg.get_master cfg with
-	    | Elected | Preferred _ | Forced _ ->
-	      begin
-	      if (m = my_name ) && (ls < instantiation_time)
-	      then None, (Printf.sprintf "%Li considered invalid lease from previous incarnation" ls)
-	      else
-		let now = Int64.of_float (Unix.time()) in
-		let diff = Int64.sub now ls in
-		if diff < Int64.of_int lease_expiration then
-		  (Some m,"inside lease")
-		else (None,Printf.sprintf "(%Li < (%Li = now) lease expired" ls now)
-	      end
-	    | ReadOnly -> Some my_name, "readonly"
+      | None -> None,"young cluster"
+      | Some (m,ls) ->
+        match Node_cfg.get_master cfg with
+        | Elected | Preferred _ | Forced _ ->
+          begin
+            let now = Int64.of_float (Unix.time()) in
+            let diff = Int64.sub now ls in
+            if diff < Int64.of_int lease_expiration then
+              (Some m,"inside lease")
+            else (None,Printf.sprintf "(%Li < (%Li = now) lease expired" ls now) 
+          end
+        | ReadOnly -> Some my_name, "readonly"
 
     in
     Logger.debug_f_ "who_master: returning %s because %s"


### PR DESCRIPTION
This backports a fix to 1.6 for the situation where a forced master too quickly starts responding to requests from clients.
The first 2 commits are cherry-picked from the 1.7 branch.
I think we should actually still discuss if we really want to backport this ...
