### PR TITLE
throw an error when sabotage is detected (instead of unpacking last .tlf...

### DIFF
--- a/extension/test/server/right/system_tests_long_right.py
+++ b/extension/test/server/right/system_tests_long_right.py
@@ -488,9 +488,7 @@ def test_sabotage():
         print f
         q.system.fs.remove(f)
 
-    cmd = []
-    command = clu._cmd('sturdy_0')
-    cmd.extend(command)
+    cmd = clu._cmd('sturdy_0')
     returncode = subprocess.call(cmd)
     assert_equals(returncode, 50)
 

--- a/extension/test/server/right/system_tests_long_right.py
+++ b/extension/test/server/right/system_tests_long_right.py
@@ -465,7 +465,7 @@ def test_fsync():
 @Common.with_custom_setup(Common.setup_1_node, Common.basic_teardown)
 def test_sabotage():
     """
-    scenario countering a sysadmin removing files (s)he shouldn't (eta : 400s)
+    scenario countering a sysadmin removing files (s)he shouldn't (eta : 160s)
     """
     clu = _getCluster()
     tlog_size = Common.get_entries_per_tlog()
@@ -487,18 +487,12 @@ def test_sabotage():
     for f in files:
         print f
         q.system.fs.remove(f)
-    clu.start()
-    delay = 80
-    logging.info("sleeping for %i", delay)
-    time.sleep(delay)
-    logging.info("doing 2000 sets")
-    Common.iterate_n_times(2000, Common.simple_set)
-    logging.info("sleeping fo 10s")
-    time.sleep(10)
 
-    size = q.system.fs.fileSize("%s/001.tlf" % node_tlf_dir)
-    logging.info("file_size = %i", size)
-    assert_true(size > 1024 * 5)
+    cmd = []
+    command = clu._cmd('sturdy_0')
+    cmd.extend(command)
+    returncode = subprocess.call(cmd)
+    assert_equals(returncode, 50)
 
 @Common.with_custom_setup( Common.setup_3_nodes_forced_master, Common.basic_teardown )
 def test_large_catchup_while_running():

--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -801,6 +801,10 @@ let _main_2 (type s)
             let rc = 49 in
             Logger.fatal_f_ "[rc=%i] Tlog has a checksum error, last valid pos = %Li" rc pos >>= fun () ->
             Lwt.return rc
+          | Tlogcommon.TLogSabotage ->
+            let rc = 50 in
+            Logger.fatal_f_ "[rc=%i] Somebody has been messing with the available tlogs" rc >>= fun () ->
+            Lwt.return rc
           | exn ->
             begin
               Logger.fatal_ ~exn "going down" >>= fun () ->

--- a/src/tlog/tlogcommon.ml
+++ b/src/tlog/tlogcommon.ml
@@ -41,6 +41,7 @@ end
 
 exception TLogCheckSumError of Int64.t
 exception TLogUnexpectedEndOfFile of Int64.t
+exception TLogSabotage
 
 let tlogEntriesPerFile =
   ref (IFDEF SMALLTLOG THEN 1000 ELSE (100 * 1000) END)


### PR DESCRIPTION
.../.tlx)
