### PR TITLE
implement Mem_store.get_location

### DIFF
--- a/src/node/mem_store.ml
+++ b/src/node/mem_store.ml
@@ -30,6 +30,7 @@ module StringMap = Map.Make(String);;
 
 type t = { mutable kv : string StringMap.t;
            mutable _tx : transaction option;
+           name : string;
          }
 
 let with_transaction ms f =
@@ -114,7 +115,7 @@ let close ms flush = Lwt.return ()
 
 let reopen ms when_closed quiesced = Lwt.return ()
 
-let get_location ms = failwith "not supported"
+let get_location ms = ms.name
 
 let get_key_count ms =
   let inc key value size =
@@ -148,7 +149,8 @@ let get_fringe ms boundary direction =
 
 let make_store ~lcnum ~ncnum read_only db_name =
   Lwt.return { kv = StringMap.empty;
-               _tx = None; }
+               _tx = None;
+               name = db_name; }
 
 let copy_store old_location new_location overwrite =
   Lwt.return ()


### PR DESCRIPTION
There is no reason whatsoever that many of the base tests should end like this:

```
    Nov  8 15:31:11: info: messaging thread finished
    Nov  8 15:31:11: info: Closing store (0s)
    Nov  8 15:31:11: debug: closing store...
    Nov  8 15:31:11: info: Closing store (0s)
    Nov  8 15:31:11: debug: closing store...
    Nov  8 15:31:11: info: Closing store (0s)
    Nov  8 15:31:11: debug: closing store...
    Nov  8 15:31:11: debug: closed store
    Nov  8 15:31:11: debug: closed store
    Nov  8 15:31:11: debug: closed store
    Nov  8 15:31:11: fatal: going down: Failure("not supported")
    Nov  8 15:31:11: fatal: going down: Failure("not supported")
    Nov  8 15:31:11: fatal: going down: Failure("not supported")
    Nov  8 15:31:11: fatal: after pick
    Nov  8 15:31:11: fatal: after pick
    Nov  8 15:31:11: fatal: after pick
    Nov  8 15:31:11: info: Not dumping state
    Nov  8 15:31:11: info: Not dumping state
    Nov  8 15:31:11: info: Not dumping state
```

Why that fatal error doesn't result in the test failing is another interesting question, which will not be answered with this branch/PR.
I do want to find out and have put it on the list of TODOs I'm maintaining.
