### PR TITLE
TravisCI: Rework build using a script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,6 @@ env:
   - PPA=avsm/ocaml41+opam10
   - PPA=avsm/ocaml41+opam11
 
-before_install:
-  - echo "yes" | sudo add-apt-repository ppa:$PPA
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq ocaml ocaml-native-compilers camlp4-extra opam libev-dev libssl-dev
-  - ocamlopt -version
-
-install:
-  - opam init -v -y
-  - eval `opam config -env`
-  - opam remote add incubaid-devel -v -y -k git git://github.com/Incubaid/opam-repository-devel.git
-  - opam update -v -y
-  - opam install -q -v -y ssl conf-libev lwt camlbz2 camltc
-
-script:
-  - eval `opam config -env`
-  - ocamlbuild -use-ocamlfind -classic-display arakoon.native
-  - ./arakoon.native --version
-  - ./arakoon.native --run-all-tests 2>&1 | tail -n256
-  - exit ${PIPESTATUS[0]}
+before_install: ./travis.sh before_install
+install: ./travis.sh install
+script: ./travis.sh script

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,71 @@
+#!/bin/bash -xue
+
+APT_DEPENDS="libev-dev libssl-dev"
+APT_OCAML_DEPENDS="ocaml ocaml-native-compilers camlp4-extra opam"
+OPAM_DEPENDS="ssl conf-libev lwt camlbz2 camltc"
+
+export OPAMYES=1
+export OPAMVERBOSE=1
+
+before_install () {
+    echo "Running 'before_install' phase"
+
+    echo "Adding PPA '$PPA'"
+    echo "yes" | sudo add-apt-repository ppa:$PPA
+    echo "Updating Apt cache"
+    sudo apt-get update -qq
+    echo "Installing general dependencies"
+    sudo apt-get install -qq ${APT_DEPENDS}
+    echo "Installing dependencies"
+    sudo apt-get install -qq ${APT_OCAML_DEPENDS}
+
+    echo "OCaml versions:"
+    ocaml -version
+    ocamlopt -version
+
+    echo "Opam versions:"
+    opam --version
+    opam --git-version
+}
+
+install () {
+    echo "Running 'install' phase"
+
+    opam init
+    eval `opam config -env`
+
+    opam remote add incubaid-devel -k git git://github.com/Incubaid/opam-repository-devel.git
+    opam update
+
+    opam install ${OPAM_DEPENDS}
+}
+
+script () {
+    echo "Running 'script' phase"
+    eval `opam config -env`
+
+    echo "Building 'arakoon.native'"
+    ocamlbuild -use-ocamlfind -classic-display arakoon.native
+
+    echo "Arakoon version:"
+    ./arakoon.native --version
+
+    echo "Executing tests"
+    ./arakoon.native --run-all-tests 2>&1 | tail -n256
+    exit ${PIPESTATUS[0]}
+}
+
+case "$1" in
+    before_install)
+        before_install
+        ;;
+    install)
+        install
+        ;;
+    script)
+        script
+        ;;
+    *)
+        echo "Usage: $0 {before_install|install|script}"
+        exit 1
+esac

--- a/travis.sh
+++ b/travis.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -xue
 
-APT_DEPENDS="libev-dev libssl-dev"
+APT_DEPENDS="libev-dev libssl-dev libsnappy-dev"
 APT_OCAML_DEPENDS="ocaml ocaml-native-compilers camlp4-extra opam"
-OPAM_DEPENDS="ssl conf-libev lwt camlbz2 camltc"
+OPAM_DEPENDS="ssl conf-libev lwt camlbz2 camltc snappy"
 
 export OPAMYES=1
 export OPAMVERBOSE=1


### PR DESCRIPTION
In order to make sure a build actually fails whenever a build-step
fails, this commit moves the steps into a shell-script which is then
executed through the TravisCI configuration file.
