### PR TITLE
ARAKOON-442: Allow slaves running `defrag` to keep participating in a cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - eval `opam config -env`
   - opam remote add incubaid-devel -v -y -k git git://github.com/Incubaid/opam-repository-devel.git
   - opam update -v -y
-  - opam install -q -v -y conf-libev lwt camlbz2 camltc.0.7.0
+  - opam install -q -v -y conf-libev lwt camlbz2 camltc.999
 
 script:
   - eval `opam config -env`

--- a/jenkins/base/008_install_dev_env.sh
+++ b/jenkins/base/008_install_dev_env.sh
@@ -12,5 +12,5 @@ opam remove -y ounit
 opam install conf-libev 
 opam install -y camlbz2 
 opam install -y "lwt.2.4.3"
-opam install -y "camltc.0.7.0"
+opam install -y "camltc.999"
 opam install -y bisect

--- a/src/node/local_store.ml
+++ b/src/node/local_store.ml
@@ -137,7 +137,11 @@ let with_transaction ls f =
 
 let defrag ls =
   Logger.info_ "local_store :: defrag" >>= fun () ->
-  Camltc.Hotc.defrag ls.db >>= fun rc ->
+  let bdb = Camltc.Hotc.get_bdb ls.db in
+  Lwt_preemptive.detach
+    (Camltc.Bdb.defrag ~step:0L)
+    bdb
+  >>= fun rc ->
   Logger.info_f_ "local_store %s :: defrag done: rc=%i" ls.location rc >>= fun () ->
   Lwt.return ()
 

--- a/src/node/local_store.ml
+++ b/src/node/local_store.ml
@@ -194,11 +194,14 @@ let close ls flush =
 
 let get_location ls = Camltc.Hotc.filename ls.db
 
-let reopen ls f quiesce_mode =
-  let mode = match quiesce_mode with
-    | Quiesce.Mode.ReadOnly -> B.readonly_mode
-    | Quiesce.Mode.Writable | Quiesce.Mode.NotQuiesced -> B.default_mode
-  in
+let reopen ls f quiesced =
+  let mode =
+    begin
+      if quiesced then
+        B.readonly_mode
+      else
+        B.default_mode
+    end in
   Logger.info_f_ "local_store %S::reopen calling Hotc::reopen" ls.location >>= fun () ->
   Camltc.Hotc.reopen ls.db f mode >>= fun () ->
   Logger.info_ "local_store::reopen Hotc::reopen succeeded"

--- a/src/node/local_store.ml
+++ b/src/node/local_store.ml
@@ -190,14 +190,11 @@ let close ls flush =
 
 let get_location ls = Camltc.Hotc.filename ls.db
 
-let reopen ls f quiesced =
-  let mode =
-    begin
-      if quiesced then
-        B.readonly_mode
-      else
-        B.default_mode
-    end in
+let reopen ls f quiesce_mode =
+  let mode = match quiesce_mode with
+    | Quiesce.Mode.ReadOnly -> B.readonly_mode
+    | Quiesce.Mode.Writable | Quiesce.Mode.NotQuiesced -> B.default_mode
+  in
   Logger.info_f_ "local_store %S::reopen calling Hotc::reopen" ls.location >>= fun () ->
   Camltc.Hotc.reopen ls.db f mode >>= fun () ->
   Logger.info_ "local_store::reopen Hotc::reopen succeeded"

--- a/src/node/store.ml
+++ b/src/node/store.ml
@@ -88,7 +88,7 @@ module type Simple_store = sig
 
   val flush: t -> unit Lwt.t
   val close: t -> bool -> unit Lwt.t
-  val reopen: t -> (unit -> unit Lwt.t) -> bool -> unit Lwt.t
+  val reopen: t -> (unit -> unit Lwt.t) -> Quiesce.Mode.t -> unit Lwt.t
   val make_store: bool -> string -> t Lwt.t
 
   val get_location: t -> string
@@ -96,7 +96,7 @@ module type Simple_store = sig
 
   val get_key_count : t -> int64 Lwt.t
 
-  val optimize : t -> bool -> unit Lwt.t
+  val optimize : t -> Quiesce.Mode.t -> unit Lwt.t
   val defrag : t -> unit Lwt.t
   val copy_store : t -> bool -> Lwt_io.output_channel -> unit Lwt.t
   val copy_store2 : string -> string -> bool -> unit Lwt.t
@@ -124,7 +124,7 @@ module type STORE =
     val relocate : t -> string -> unit Lwt.t
 
     val quiesced : t -> bool
-    val quiesce : t -> unit Lwt.t
+    val quiesce : Quiesce.Mode.t -> t -> unit Lwt.t
     val unquiesce : t -> unit Lwt.t
     val optimize : t -> unit Lwt.t
     val defrag : t -> unit Lwt.t
@@ -171,7 +171,7 @@ struct
                mutable master : (string * int64) option;
                mutable interval : Interval.t;
                mutable routing : Routing.t option;
-               mutable quiesced : bool;
+               mutable quiesced : Quiesce.Mode.t;
                mutable closed : bool;
                mutable _tx_lock : transaction_lock option;
                _tx_lock_mutex : Lwt_mutex.t
@@ -221,7 +221,7 @@ struct
         master;
         interval;
         routing;
-        quiesced = false;
+        quiesced = Quiesce.Mode.NotQuiesced;
         closed = false;
         _tx_lock = None;
         _tx_lock_mutex = Lwt_mutex.create ()
@@ -296,21 +296,20 @@ struct
   let relocate store loc =
     S.relocate store.s loc
 
-  let quiesced store =
-    store.quiesced
+  let quiesced store = Quiesce.Mode.is_quiesced store.quiesced
 
-  let quiesce store =
-    if store.quiesced
+  let quiesce mode store =
+    if quiesced store
     then Lwt.fail(Failure "Store already quiesced. Blocking second attempt")
     else
       begin
-        store.quiesced <- true;
+        store.quiesced <- mode;
 	    reopen store (fun () -> Lwt.return ()) >>= fun () ->
 	    Lwt.return ()
       end
 
   let unquiesce store =
-    store.quiesced <- false;
+    store.quiesced <- Quiesce.Mode.NotQuiesced;
     reopen store (fun () -> Lwt.return ())
 
   let optimize store =
@@ -327,7 +326,7 @@ struct
       Lwt.return ())
 
   let set_master_no_inc store master lease_start =
-    if store.quiesced
+    if quiesced store
     then
       begin
         store.master <- Some (master, lease_start);
@@ -377,7 +376,7 @@ struct
       (Log_extra.option2s Sn.string_of old_i) (Sn.string_of new_i)
 
   let incr_i store =
-    if store.quiesced
+    if quiesced store
     then
       begin
         let new_i = _new_i store.store_i in
@@ -401,7 +400,7 @@ struct
     S.get_fringe store.s b d
 
   let copy_store store oc =
-    if store.quiesced
+    if quiesced store
     then
       S.copy_store store.s true oc
     else
@@ -770,7 +769,7 @@ struct
                 else Llio.lwt_failfmt "update %s, store @ %s don't fit" (Sn.string_of n) (Sn.string_of m)
         end
         >>= fun () ->
-        if store.quiesced
+        if quiesced store
         then
           begin
             incr_i store >>= fun () ->
@@ -806,7 +805,7 @@ struct
                 Llio.lwt_failfmt "Invalid store update requested (%s : %s)"
                   (Sn.string_of i) (Sn.string_of store_i)
       end >>= fun () ->
-      if store.quiesced
+      if quiesced store
       then
         begin
           incr_i store >>= fun () ->

--- a/src/node/sync_backend.ml
+++ b/src/node/sync_backend.ml
@@ -560,14 +560,12 @@ object(self: #backend)
 
   method private quiesce_db ~mode () =
     self # _not_if_master () >>= fun () ->
-    let result = ref Quiesce.Result.Fail in
     let sleep, awake = Lwt.wait() in
     let update = Multi_paxos.Quiesce (mode, sleep, awake) in
     Logger.info_ "quiesce_db: Pushing quiesce request" >>= fun () ->
     push_node_msg update >>= fun () ->
     Logger.info_ "quiesce_db: waiting for quiesce request to be completed" >>= fun () ->
     sleep >>= fun res ->
-    result := res;
     Logger.info_ "quiesce_db: db is now completed" >>= fun () ->
     match res with
       | Quiesce.Result.OK -> Lwt.return ()

--- a/src/node/sync_backend.ml
+++ b/src/node/sync_backend.ml
@@ -598,7 +598,8 @@ object(self: #backend)
   method defrag_db () =
     self # _not_if_master() >>= fun () ->
     Logger.info_ "defrag_db: enter" >>= fun () ->
-    S.defrag store >>= fun () ->
+    let mode = Quiesce.Mode.Writable in
+    self # try_quiesced ~mode (fun () -> S.defrag store) >>= fun () ->
     Logger.info_ "defrag_db: exit"
 
 

--- a/src/node/sync_backend.ml
+++ b/src/node/sync_backend.ml
@@ -558,11 +558,11 @@ object(self: #backend)
     self # _read_allowed false >>= fun () ->
     S.get_key_count store
 
-  method private quiesce_db () =
+  method private quiesce_db ~mode () =
     self # _not_if_master () >>= fun () ->
-    let result = ref Multi_paxos.Quiesced_fail in
+    let result = ref Quiesce.Result.Fail in
     let sleep, awake = Lwt.wait() in
-    let update = Multi_paxos.Quiesce (sleep, awake) in
+    let update = Multi_paxos.Quiesce (mode, sleep, awake) in
     Logger.info_ "quiesce_db: Pushing quiesce request" >>= fun () ->
     push_node_msg update >>= fun () ->
     Logger.info_ "quiesce_db: waiting for quiesce request to be completed" >>= fun () ->
@@ -570,10 +570,10 @@ object(self: #backend)
     result := res;
     Logger.info_ "quiesce_db: db is now completed" >>= fun () ->
     match res with
-      | Multi_paxos.Quiesced_ok -> Lwt.return ()
-      | Multi_paxos.Quiesced_fail_master ->
+      | Quiesce.Result.OK -> Lwt.return ()
+      | Quiesce.Result.FailMaster ->
         Lwt.fail (XException(Arakoon_exc.E_UNKNOWN_FAILURE, "Operation cannot be performed on master node"))
-      | Multi_paxos.Quiesced_fail ->
+      | Quiesce.Result.Fail ->
         Lwt.fail (XException(Arakoon_exc.E_UNKNOWN_FAILURE, "Store could not be quiesced"))
 
   method private unquiesce_db () =
@@ -581,8 +581,8 @@ object(self: #backend)
     let update = Multi_paxos.Unquiesce in
     push_node_msg update
 
-  method try_quiesced f =
-    self # quiesce_db () >>= fun () ->
+  method try_quiesced ~mode f =
+    self # quiesce_db ~mode () >>= fun () ->
     begin
       Lwt.finalize
       ( f )
@@ -591,7 +591,8 @@ object(self: #backend)
 
   method optimize_db () =
     Logger.info_ "optimize_db: enter" >>= fun () ->
-    self # try_quiesced(fun () -> S.optimize store) >>= fun () ->
+    let mode = Quiesce.Mode.ReadOnly in
+    self # try_quiesced ~mode (fun () -> S.optimize store) >>= fun () ->
     Logger.info_ "optimize_db: All done"
 
   method defrag_db () =
@@ -610,7 +611,8 @@ object(self: #backend)
           Lwt.fail ex
         | Some oc -> Lwt.return oc
     end >>= fun oc ->
-    self # try_quiesced ( fun () -> S.copy_store store oc ) >>= fun () ->
+    let mode = Quiesce.Mode.ReadOnly in
+    self # try_quiesced ~mode ( fun () -> S.copy_store store oc ) >>= fun () ->
     Logger.info_ "get_db: All done"
 
   method get_cluster_cfgs () =

--- a/src/paxos/master.ml
+++ b/src/paxos/master.ml
@@ -186,9 +186,9 @@ let stable_master (type s) constants ((v',n,new_i, lease_expire_waiters) as curr
           in          
           Fsm.return ~sides:[log_e] (Stable_master current_state)
       end
-    | Quiesce (sleep,awake) ->
+    | Quiesce (_, sleep,awake) ->
       begin
-        fail_quiesce_request constants.store sleep awake Quiesced_fail_master >>= fun () ->
+        fail_quiesce_request constants.store sleep awake Quiesce.Result.FailMaster >>= fun () ->
         Fsm.return (Stable_master current_state)
       end
         

--- a/src/paxos/multi_paxos.ml
+++ b/src/paxos/multi_paxos.ml
@@ -96,16 +96,11 @@ let update_votes (nones,somes) = function
     let somes' = List.sort (fun (a,fa) (b,fb) -> fb - fa) tmp in
     (nones, somes')
 
-type quiesce_result =
-  | Quiesced_ok
-  | Quiesced_fail_master
-  | Quiesced_fail
- 				      
 type paxos_event =
   | FromClient of ((Update.Update.t) * (Store.update_result -> unit Lwt.t)) list
   | FromNode of (MPMessage.t * Messaging.id)
   | LeaseExpired of Sn.t
-  | Quiesce of (quiesce_result Lwt.t * quiesce_result Lwt.u)
+  | Quiesce of (Quiesce.Mode.t * Quiesce.Result.t Lwt.t * Quiesce.Result.t Lwt.u)
   | Unquiesce
   | ElectionTimeout of Sn.t
   | DropMaster of (unit Lwt.t * unit Lwt.u)
@@ -114,7 +109,7 @@ let paxos_event2s = function
   | FromClient _ -> "FromClient _"
   | FromNode _ -> "FromNode _ "
   | LeaseExpired _ -> "LeaseExpired _"
-  | Quiesce _ -> "Quiesce _"
+  | Quiesce (mode, _, _) -> Printf.sprintf "Quiesce (%s, _, _)" (Quiesce.Mode.to_string mode)
   | Unquiesce -> "Unquiesce _"
   | ElectionTimeout _ -> "ElectionTimeout _"
   | DropMaster _ -> "DropMaster _"
@@ -323,9 +318,9 @@ let safe_wakeup_all v l =
 let fail_quiesce_request store sleeper awake reason =
   safe_wakeup sleeper awake reason
   
-let handle_quiesce_request (type s) (module S : Store.STORE with type t = s) store sleeper (awake: quiesce_result Lwt.u) =
-  S.quiesce store >>= fun () ->
-  safe_wakeup sleeper awake Quiesced_ok
+let handle_quiesce_request (type s) (module S : Store.STORE with type t = s) store mode sleeper (awake: Quiesce.Result.t Lwt.u) =
+  S.quiesce mode store >>= fun () ->
+  safe_wakeup sleeper awake Quiesce.Result.OK
 
 let handle_unquiesce_request (type s) constants n =
   let store = constants.store in

--- a/src/paxos/multi_paxos_fsm.ml
+++ b/src/paxos/multi_paxos_fsm.ml
@@ -157,8 +157,8 @@ let slave_waiting_for_prepare (type s) constants ( (current_i:Sn.t),(current_n:S
         else Fsm.return (Slave_waiting_for_prepare(current_i, current_n))
     | FromClient _ -> paxos_fatal constants.me "Slave_waiting_for_prepare cannot handle client requests"
     
-    | Quiesce (sleep,awake) ->
-        handle_quiesce_request (module S) constants.store sleep awake >>= fun () ->
+    | Quiesce (mode, sleep,awake) ->
+        handle_quiesce_request (module S) constants.store mode sleep awake >>= fun () ->
         Fsm.return (Slave_waiting_for_prepare (current_i,current_n) )
           
     | Unquiesce ->
@@ -452,8 +452,8 @@ let wait_for_promises (type s) constants state event =
     | FromClient _ -> 
         paxos_fatal me "wait_for_promises: don't want FromClient"
           
-    | Quiesce (sleep,awake) ->
-        handle_quiesce_request (module S) constants.store sleep awake >>= fun () ->
+    | Quiesce (mode, sleep,awake) ->
+        handle_quiesce_request (module S) constants.store mode sleep awake >>= fun () ->
         Fsm.return (Wait_for_promises state)
       
     | Unquiesce ->
@@ -698,8 +698,8 @@ let wait_for_accepteds (type s) constants state (event:paxos_event) =
 	      end
       end
 	    
-    | Quiesce (sleep,awake) ->
-      fail_quiesce_request constants.store sleep awake Quiesced_fail_master >>= fun () ->
+    | Quiesce (mode, sleep,awake) ->
+      fail_quiesce_request constants.store sleep awake Quiesce.Result.FailMaster >>= fun () ->
       Fsm.return (Wait_for_accepteds state)
       
     | Unquiesce ->

--- a/src/paxos/quiesce.ml
+++ b/src/paxos/quiesce.ml
@@ -1,0 +1,47 @@
+(*
+This file is part of Arakoon, a distributed key-value store. Copyright
+(C) 2013 Incubaid BVBA
+
+Licensees holding a valid Incubaid license may use this file in
+accordance with Incubaid's Arakoon commercial license agreement. For
+more information on how to enter into this agreement, please contact
+Incubaid (contact details can be found on www.arakoon.org/licensing).
+
+Alternatively, this file may be redistributed and/or modified under
+the terms of the GNU Affero General Public License version 3, as
+published by the Free Software Foundation. Under this license, this
+file is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU Affero General Public License for more details.
+You should have received a copy of the
+GNU Affero General Public License along with this program (file "COPYING").
+If not, see <http://www.gnu.org/licenses/>.
+*)
+
+module Mode = struct
+  type t = NotQuiesced
+         | ReadOnly
+         | Writable
+
+  let to_string = function
+    | NotQuiesced -> "NotQuiesced"
+    | ReadOnly -> "ReadOnly"
+    | Writable -> "Writable"
+
+  let is_quiesced = function
+    | NotQuiesced -> false
+    | ReadOnly | Writable -> true
+end
+
+module Result = struct
+  type t = OK
+         | FailMaster
+         | Fail
+
+  let to_string = function
+    | OK -> "OK"
+    | FailMaster -> "FailMaster"
+    | Fail -> "Fail"
+end

--- a/src/paxos/slave.ml
+++ b/src/paxos/slave.ml
@@ -221,9 +221,9 @@ let slave_steady_state (type s) constants state event =
           loop finished_funs >>= fun () ->
           Fsm.return  (Slave_steady_state(n,i,previous))
         end
-    | Quiesce (sleep,awake) ->
+    | Quiesce (mode, sleep,awake) ->
         begin
-          handle_quiesce_request (module S) constants.store sleep awake >>= fun () ->
+          handle_quiesce_request (module S) constants.store mode sleep awake >>= fun () ->
           Fsm.return (Slave_steady_state state)
         end
           
@@ -407,9 +407,9 @@ let slave_wait_for_accept (type s) constants (n,i, vo, maybe_previous) event =
             
     | FromClient msg -> paxos_fatal constants.me "slave_wait_for_accept only registered for FromNode"
       
-    | Quiesce (sleep,awake) ->
+    | Quiesce (mode, sleep,awake) ->
         begin
-          handle_quiesce_request (module S) constants.store sleep awake >>= fun () ->
+          handle_quiesce_request (module S) constants.store mode sleep awake >>= fun () ->
           Fsm.return (Slave_wait_for_accept (n,i, vo, maybe_previous))
         end
     | Unquiesce ->


### PR DESCRIPTION
Manual testing looks OK, as described on Skype.

CI succeeded except `arakoon_system_tests.server.right.system_tests_long_right.test_large_catchup_while_running` (`arakoon-git-system-tests-slow-RIGHT` #2922), but this seems unrelated.
