### PR TITLE
Pass 'open modes' instead of 'quiesced' flags to a store

### DIFF
--- a/src/main/replay_main.ml
+++ b/src/main/replay_main.ml
@@ -23,7 +23,7 @@ let replay_tlogs tlog_dir tlf_dir db_name end_i =
   let t () = 
     Lwt.catch 
       (fun () ->
-        S.make_store db_name >>= fun store ->
+        S.make_store [Store.OpenMode.OCREAT; Store.OpenMode.OWRITER] db_name >>= fun store ->
         let cio = S.consensus_i store in
         let cios = Log_extra.option2s Sn.string_of cio in
         console "store @ %s" cios >>= fun () ->

--- a/src/node/catchup.ml
+++ b/src/node/catchup.ml
@@ -89,7 +89,7 @@ let head_saved_epilogue hfn tlog_coll =
   *)
   Logger.info_f_ "head_saved_epilogue %s" hfn >>= fun () ->
   let module S = (val (Store.make_store_module (module Batched_store.Local_store))) in
-  S.make_store ~read_only:true hfn >>= fun store ->
+  S.make_store [Store.OpenMode.OREADER] hfn >>= fun store ->
   let hio = S.consensus_i store in
   S.close store >>= fun () ->
   Logger.info_ "closed head" >>= fun () ->

--- a/src/node/catchup_test.ml
+++ b/src/node/catchup_test.ml
@@ -117,7 +117,7 @@ let test_common () =
   _fill tlog_coll 1000 >>= fun () ->
   let me = "" in
   let db_name = _dir_name ^ "/my_store1.db" in
-  S.make_store db_name >>= fun store ->
+  S.make_store [Store.OpenMode.OCREAT; Store.OpenMode.OWRITER] db_name >>= fun store ->
   Catchup.catchup_store me ((module S),store,tlog_coll) 500L >>= fun() ->
   Logger.info_ "TODO: validate store after this" >>= fun ()->
   tlog_coll # close () >>= fun () ->
@@ -144,7 +144,7 @@ let _tic (type s) filler_function n name verify_store =
   Tlc2.make_tlc2 _dir_name _tlf_dir _tlf_dir true false "node_name" >>= fun tlog_coll ->
   filler_function tlog_coll n >>= fun () ->
   let db_name = _dir_name ^ "/" ^ name ^ ".db" in
-  S.make_store db_name >>= fun store ->
+  S.make_store [Store.OpenMode.OCREAT; Store.OpenMode.OWRITER] db_name >>= fun store ->
   let me = "??me??" in
   Catchup.verify_n_catchup_store me ((module S), store, tlog_coll)
   >>= fun () ->

--- a/src/node/collapser.ml
+++ b/src/node/collapser.ml
@@ -43,7 +43,7 @@ let collapse_until (type s) (tlog_coll:Tlogcollection.tlog_collection)
     )
   >>= fun () ->
   Logger.debug_f_ "Creating store at %s" new_location >>= fun () ->
-  S.make_store new_location >>= fun new_store ->
+  S.make_store [Store.OpenMode.OCREAT; Store.OpenMode.OWRITER] new_location >>= fun new_store ->
   Lwt.finalize (
     fun () ->
 	  tlog_coll # get_infimum_i () >>= fun min_i ->
@@ -154,8 +154,7 @@ let collapse_until (type s) (tlog_coll:Tlogcollection.tlog_collection)
 let _head_i (type s) (module S : Store.STORE with type t = s) head_location =
   Lwt.catch
     (fun () ->
-      let read_only=true in
-      S.make_store ~read_only head_location >>= fun head ->
+      S.make_store [Store.OpenMode.OREADER] head_location >>= fun head ->
       let head_io = S.consensus_i head in
       S.close head >>= fun () ->
       Lwt.return head_io

--- a/src/node/dump_store.ml
+++ b/src/node/dump_store.ml
@@ -39,7 +39,7 @@ let summary store =
 
 let dump_store filename = 
   let t () = 
-    S.make_store filename >>= fun store ->
+    S.make_store [Store.OpenMode.OREADER] filename >>= fun store ->
     summary store >>= fun () ->
     S.close store
   in
@@ -66,11 +66,11 @@ let inject_as_head fn node_id cfg_fn =
     let tlf_dir = node_cfg.tlf_dir in
     let head_dir = node_cfg.head_dir in
     let old_head_name = Filename.concat head_dir Tlc2.head_fname  in
-    S.make_store old_head_name >>= fun old_head ->
+    S.make_store [Store.OpenMode.OREADER] old_head_name >>= fun old_head ->
     let old_head_i = S.consensus_i old_head in
     S.close old_head      >>= fun () ->
 
-    S.make_store fn >>= fun new_head ->
+    S.make_store [Store.OpenMode.OREADER] fn >>= fun new_head ->
     let new_head_i = S.consensus_i new_head in
     S.close new_head      >>= fun () ->
 

--- a/src/node/local_store.ml
+++ b/src/node/local_store.ml
@@ -67,8 +67,16 @@ let copy_store2 old_location new_location overwrite =
   else
     File_system.copy_file old_location new_location overwrite
 
+let bdb_open_mode mode =
+  let map_mode = function
+    | OpenMode.OREADER -> Camltc.Bdb.OpenMode.OREADER
+    | OpenMode.OWRITER -> Camltc.Bdb.OpenMode.OWRITER
+    | OpenMode.OCREAT -> Camltc.Bdb.OpenMode.OCREAT
+  in
+  Camltc.Bdb.OpenMode.OLCKNB :: List.map map_mode mode
+
 let safe_create db_path mode =
-  Camltc.Hotc.create db_path ~mode [B.BDBTLARGE] >>= fun db ->
+  Camltc.Hotc.create db_path ~mode:(bdb_open_mode mode) [B.BDBTLARGE] >>= fun db ->
   let flags = Camltc.Bdb.flags (Camltc.Hotc.get_bdb db) in
   if List.mem Camltc.Bdb.BDBFFATAL flags
     then Lwt.fail (BdbFFatal db_path)
@@ -191,15 +199,8 @@ let close ls flush =
 let get_location ls = Camltc.Hotc.filename ls.db
 
 let reopen ls f mode =
-  let map_mode = function
-    | OpenMode.OREADER -> Camltc.Bdb.OpenMode.OREADER
-    | OpenMode.OWRITER -> Camltc.Bdb.OpenMode.OWRITER
-    | OpenMode.OCREAT -> Camltc.Bdb.OpenMode.OCREAT
-  in
-  let bdb_mode = Camltc.Bdb.OpenMode.OLCKNB :: List.map map_mode mode in
-
   Logger.info_f_ "local_store %S::reopen calling Hotc::reopen" ls.location >>= fun () ->
-  Camltc.Hotc.reopen ls.db f bdb_mode >>= fun () ->
+  Camltc.Hotc.reopen ls.db f (bdb_open_mode mode) >>= fun () ->
   Logger.info_ "local_store::reopen Hotc::reopen succeeded"
 
 let get_key_count ls =
@@ -236,7 +237,7 @@ let optimize ls mode =
   >>= fun () ->
   begin
     Logger.info_f_ "Creating new db object at location %s" db_optimal >>= fun () ->
-    safe_create db_optimal Camltc.Bdb.default_mode >>= fun db_opt ->
+    safe_create db_optimal [Store.OpenMode.OCREAT; Store.OpenMode.OWRITER] >>= fun db_opt ->
     Lwt.finalize
       ( fun () ->
         Logger.info_ "Optimizing db copy" >>= fun () ->
@@ -352,12 +353,7 @@ let get_fringe ls border direction =
       Logger.debug_f_ "buf:%s" (Buffer.contents buf)
     )
 
-let make_store read_only db_name =
-  let mode =
-    if read_only
-    then B.readonly_mode
-    else B.default_mode
-  in
+let make_store mode db_name =
   Logger.info_f_ "Creating local store at %s" db_name >>= fun () ->
   get_construct_params db_name ~mode
   >>= fun db ->

--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -208,7 +208,7 @@ let only_catchup (type s) (module S : Store.STORE with type t = s) ~name ~cluste
           fo.node_name
     end
   in
-  S.make_store db_name >>= fun store ->
+  S.make_store [Store.OpenMode.OCREAT; Store.OpenMode.OWRITER] db_name >>= fun store ->
   make_tlog_coll
     me.tlog_dir me.tlf_dir me.head_dir
     me.use_compression me.fsync name >>= fun tlc ->
@@ -444,7 +444,7 @@ let _main_2 (type s)
           >>= fun () ->
           make_tlog_coll me.tlog_dir me.tlf_dir me.head_dir me.use_compression me.fsync name
           >>= fun (tlog_coll:Tlogcollection.tlog_collection) ->
-          S.make_store db_name >>= fun (store:S.t) ->
+          S.make_store [Store.OpenMode.OCREAT; Store.OpenMode.OWRITER] db_name >>= fun (store:S.t) ->
           Catchup.verify_n_catchup_store me.node_name
             ((module S), store, tlog_coll)
             ~apply_last_tlog_value:(n_nodes = 1) >>= fun () ->

--- a/src/node/store.ml
+++ b/src/node/store.ml
@@ -95,7 +95,7 @@ module type Simple_store = sig
   val flush: t -> unit Lwt.t
   val close: t -> bool -> unit Lwt.t
   val reopen: t -> (unit -> unit Lwt.t) -> OpenMode.t list -> unit Lwt.t
-  val make_store: bool -> string -> t Lwt.t
+  val make_store: OpenMode.t list -> string -> t Lwt.t
 
   val get_location: t -> string
   val relocate: t -> string -> unit Lwt.t
@@ -119,7 +119,7 @@ module type STORE =
   sig
     type ss
     type t
-    val make_store : ?read_only:bool -> string -> t Lwt.t
+    val make_store : OpenMode.t list -> string -> t Lwt.t
     val consensus_i : t -> Sn.t option
     val flush : t -> unit Lwt.t
     val close : ?flush : bool -> t -> unit Lwt.t
@@ -215,8 +215,8 @@ struct
     with Not_found -> None
 
 
-  let make_store ?(read_only=false) db_name =
-    S.make_store read_only db_name >>= fun simple_store ->
+  let make_store mode db_name =
+    S.make_store mode db_name >>= fun simple_store ->
     let store_i = _consensus_i simple_store
     and master = _master simple_store
     and interval = _get_interval simple_store

--- a/src/node/store_test.ml
+++ b/src/node/store_test.ml
@@ -64,9 +64,9 @@ let teardown () =
     >>= fun () ->
   Logger.debug_ "end of teardown"
 
-let with_store name f =
+let with_store mode name f =
   let db_name = _dir_name ^ "/" ^ name ^ ".db" in
-  S.make_store db_name >>= fun store ->
+  S.make_store mode db_name >>= fun store ->
   f store >>= fun () ->
   S.close store
 
@@ -108,11 +108,11 @@ let test_safe_insert_value () =
           asserts)
       value_asserts in
   Logger.info_ "applying updates without surrounding transaction" >>= fun () ->
-  with_store "tsiv" (fun store ->
+  with_store [Store.OpenMode.OCREAT; Store.OpenMode.OWRITER] "tsiv" (fun store ->
     do_asserts store)
 
 let test_safe_insert_value_with_partial_value_update () =
-  with_store "tsivwpvu" (fun store ->
+  with_store [Store.OpenMode.OCREAT; Store.OpenMode.OWRITER] "tsivwpvu" (fun store ->
     let k = "key" in
     let u1 = Update.TestAndSet(k, Some "value1", Some "illegal")
     and u2 = Update.TestAndSet(k, None, Some "value1")

--- a/src/paxos/multi_paxos_test.ml
+++ b/src/paxos/multi_paxos_test.ml
@@ -65,7 +65,7 @@ let test_generic network_factory n_nodes () =
   let last_witnessed who = Sn.of_int (-1000) in
   let inject_buffer = Lwt_buffer.create_fixed_capacity 1 in
   let inject_ev q e = Lwt_buffer.add e q in
-  S.make_store "MEM#store" >>= fun store ->
+  S.make_store [Store.OpenMode.OCREAT; Store.OpenMode.OWRITER] "MEM#store" >>= fun store ->
   Mem_tlogcollection.make_mem_tlog_collection "MEM#tlog" None None true "???">>= fun tlog_coll ->
   let base = {me = "???";
 	          others = [] ;
@@ -234,7 +234,7 @@ let test_master_loop network_factory ()  =
   let election_timeout_buffer = Lwt_buffer.create() in
   let inject_event e = Lwt_buffer.add e inject_buffer in
 
-  S.make_store "MEM#store" >>= fun store ->
+  S.make_store [Store.OpenMode.OCREAT; Store.OpenMode.OWRITER] "MEM#store" >>= fun store ->
   Mem_tlogcollection.make_mem_tlog_collection "MEM#tlog" None None true me >>= fun tlog_coll ->
   let constants = {me = me; 
 		   is_learner = false;
@@ -354,7 +354,7 @@ let test_simulation filters () =
       Logger.debug_f_ "got (%s,%s,%s) => dropping" msg_s source target
   in
   
-  S.make_store "MEM#store"  >>= fun store ->
+  S.make_store [Store.OpenMode.OCREAT; Store.OpenMode.OWRITER] "MEM#store"  >>= fun store ->
   Mem_tlogcollection.make_mem_tlog_collection "MEM#tlog" None None true me >>= fun tlog_coll ->
   let constants = {
     me = me;

--- a/src/system/startup.ml
+++ b/src/system/startup.ml
@@ -90,8 +90,8 @@ let _make_run ~stores ~tlcs ~now ~values ~get_cfgs name () =
   let module S =
       struct
         include LS
-        let make_store ?(read_only=false) (db_name:string) =
-          LS.make_store db_name >>= fun store ->
+        let make_store mode (db_name:string) =
+          LS.make_store mode db_name >>= fun store ->
           LS.with_transaction store (fun tx -> LS.set_master store tx name now) >>= fun () -> 
           Hashtbl.add stores db_name store;
           Lwt.return store

--- a/src/tlog/tlc2.ml
+++ b/src/tlog/tlc2.ml
@@ -606,7 +606,7 @@ object(self: # tlog_collection)
     >>= fun () ->
     Lwt_io.flush oc >>= fun () ->
     let module S = (val (Store.make_store_module (module Batched_store.Local_store))) in
-    S.make_store head_name >>= fun store ->
+    S.make_store [Store.OpenMode.OREADER] head_name >>= fun store ->
     let io = S.consensus_i store in
     S.close store >>= fun () ->
     Logger.debug_f_ "head has consensus_i=%s" (Log_extra.option2s Sn.string_of io)


### PR DESCRIPTION
In line with a comment made in #252, this commit changes some code in
the `Store` subsystem to not accept `bool` values denoting
'quiesced mode' (something a store should be oblivious of), but use
'open mode' flags instead.
