### PR TITLE
sleep a bit after starting a node and before asserting how many nodes ar...

### DIFF
--- a/extension/test/server/right/system_tests_learner.py
+++ b/extension/test/server/right/system_tests_learner.py
@@ -49,6 +49,8 @@ def test_learner():
     cluster.createDirs(name)
     cluster.startOne(name)
 
+    time.sleep(1.0)
+
     Common.assert_running_nodes(3)
     time.sleep(op_count / 1000 + 1 ) # 1000/s in catchup should be no problem
     #use a client ??"


### PR DESCRIPTION
...e running

based on

http://172.19.49.85/view/arakoon-git/job/arakoon-amplidata-git-system-tests-slow-RIGHT/lastCompletedBuild/testReport/arakoon_system_tests.server.right/system_tests_learner/test_learner/
http://10.101.186.8/jenkins/jobs/jenkins-arakoon-amplidata-git-system-tests-slow-RIGHT-9/home/jenkinslxc/qbase3/var/tmp/arakoon_system_tests/test_learner/sturdy_2/log/
