### PR TITLE
Return `E_NOT_SUPPORTED` from slave-only calls on master

### DIFF
--- a/src/node/sync_backend.ml
+++ b/src/node/sync_backend.ml
@@ -402,7 +402,7 @@ struct
           if m = my_name
           then
             let msg = "Operation cannot be performed on master node" in
-            Lwt.fail (XException(Arakoon_exc.E_UNKNOWN_FAILURE, msg))
+            Lwt.fail (XException(Arakoon_exc.E_NOT_SUPPORTED, msg))
           else
             Lwt.return ()
 
@@ -567,7 +567,7 @@ struct
         match res with
         | Quiesce.Result.OK -> Lwt.return ()
         | Quiesce.Result.FailMaster ->
-          Lwt.fail (XException(Arakoon_exc.E_UNKNOWN_FAILURE, "Operation cannot be performed on master node"))
+          Lwt.fail (XException(Arakoon_exc.E_NOT_SUPPORTED, "Operation cannot be performed on master node"))
         | Quiesce.Result.Fail ->
           Lwt.fail (XException(Arakoon_exc.E_UNKNOWN_FAILURE, "Store could not be quiesced"))
 


### PR DESCRIPTION
This commit changes the error returned from `_not_if_master` and `quiesce_db` from `E_UNKNOWN_FAILURE` (which closes the client socket) to `E_NOT_SUPPORTED` (which keeps the client socket as-is) in case the call is only valid on non-master nodes.
