### PR TITLE
fix test_download_db

### DIFF
--- a/extension/test/server/quick/system_tests_basic.py
+++ b/extension/test/server/quick/system_tests_basic.py
@@ -601,7 +601,7 @@ def test_download_db():
     n0 = C.node_names[0]
     n1 = C.node_names[1]
     C.startOne(n0)
-    time.sleep(0.1)
+    time.sleep(1.0)
     db_file = C.get_node_db_file (n1)
 
     # since there is only 1 node running, there can't be a master and


### PR DESCRIPTION
This should probably fix the failure I saw at http://172.19.49.85/view/arakoon-git/job/arakoon-amplidata-git-system-tests-QUICK/31/testReport/junit/arakoon_system_tests.server.quick/system_tests_basic/test_download_db/ .
If you have better ideas, which are applicable here, then please share.
