### PR TITLE
slaves shouldn't ignore a master just because it's n is lower

### DIFF
--- a/src/paxos/slave.ml
+++ b/src/paxos/slave.ml
@@ -174,12 +174,11 @@ let slave_steady_state (type s) constants state event =
               end
             else
               accept_value None n' i' v "steady_state :: replying again to previous with %S"
-          | Accept (n',i',v) when
-              (n'<=n && i'<i) || (n'< n)  ->
+          | Accept (n',i',v) when i' <= i ->
             begin
               let log_e = ELog (
                   fun () ->
-                    Printf.sprintf "slave_steady_state received old %S for my n, ignoring"
+                    Printf.sprintf "slave_steady_state received old %S for my i, ignoring"
                       (string_of msg) )
               in
               Fsm.return ~sides:[log_e0;log_e] (Slave_steady_state state)


### PR DESCRIPTION
noticed the problem here: http://172.19.49.85/view/arakoon-1.7/job/arakoon-1.7-system-tests-slow-RIGHT/156/testReport/junit/arakoon_system_tests.server.right/system_tests_long_right/test_disable_tlog_compression/

Tests are still running
http://172.19.49.85/view/arakoon-git/job/arakoon-git-launcher/170/downstreambuildview/?
but not expecting any problems there
