### PR TITLE
added dependencies to ssl and camlbz2

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -39,7 +39,7 @@ let machine = run_cmd "uname -mnrpio"
 
 let compiler_version = run_cmd "ocamlopt -version"
 
-let dependencies = output_cmd "opam list -i | grep 'lwt\\|ounit\\|camltc\\|snappy'"
+let dependencies = output_cmd "opam list -i | grep 'lwt\\|ounit\\|camltc\\|snappy\\|ssl\\|camlbz2'"
 
 let split s ch =
   let x = ref [] in


### PR DESCRIPTION
```
version: 1.7.-1
git_revision: "heads/1.7-0-g8ef5bac-dirty"
compiled: "15/01/2014 10:15:51 UTC"
machine: "ubuntu 3.0.0-32-generic x86_64 x86_64 x86_64 GNU/Linux"
compiler_version : "4.00.1"
tlogEntriesPerFile: 100000
dependencies:
camlbz2        0.6.0  Bindings for bzip2
camltc         0.8.2  OCaml bindings for tokyo cabinet
lwt            2.4.4  A cooperative threads library for OCaml
ounit          2.0.0  Unit testing framework loosely based on HUnit. It is similar to JUnit, and other XUnit testing frameworks
snappy         0.1.0  Bindings to snappy - fast compression/decompression library
ssl            0.4.6  Bindings for the libssl
```
