### PR TITLE
test drop master with a cluster that needs the previous master to make progress

### DIFF
--- a/extension/test/server/right/system_tests_long_right.py
+++ b/extension/test/server/right/system_tests_long_right.py
@@ -334,6 +334,7 @@ def drop_master(n):
 
 @Common.with_custom_setup( Common.setup_3_nodes, Common.basic_teardown)
 def test_drop_master():
+    Common.stopOne( Common.node_names[0] )
     n = 20
     drop_master(n)
 """    drop_masters = lambda : drop_master(n)
@@ -343,6 +344,7 @@ def test_drop_master():
 def _test_drop_master_with_load_(client):
     global busy, excs
 
+    Common.stopOne( Common.node_names[0] )
     n = 40
 
     busy = True


### PR DESCRIPTION
I think this is a better test, but maybe even better would be to test both situations?
