### PR TITLE
wider margin for collapse timing + use slowdown in test_concurrent_collapse_fails

### DIFF
--- a/cfg/arakoon.ini
+++ b/cfg/arakoon.ini
@@ -95,7 +95,7 @@ log_config = default_log_config
 # sleep time is calculated by multiplying the time the previous transaction
 # took to process with the configured number.
 # As an example, when this is set to 1.0, the collapsing process will take
-# twice as long to complete compared to no throttling being enabled.
+# at least twice as long to complete compared to no throttling being enabled.
 #collapse_slowdown = 1.5
 
 # for debugging

--- a/extension/server/ArakoonManagement.py
+++ b/extension/server/ArakoonManagement.py
@@ -542,6 +542,20 @@ class ArakoonCluster:
         for n in nodes:
             config.addParam( n, "log_level", level )
 
+    def setCollapseSlowdown(self, collapseSlowdown, nodes=None):
+        if nodes is None:
+            nodes = self.listNodes()
+        else:
+            for n in nodes :
+                self.__validateName( n )
+        config = self._getConfigFile()
+
+        for n in nodes:
+            if collapseSlowdown:
+                config.addParam(n, "collapse_slowdown", collapseSlowdown)
+            else:
+                config.removeParam(n, "collapse_slowdown")
+
     def _setTlogCompression(self,nodes, compressor):
         if nodes is None:
             nodes = self.listNodes()

--- a/extension/test/server/left/test_collapse_slowdown.py
+++ b/extension/test/server/left/test_collapse_slowdown.py
@@ -56,4 +56,4 @@ def test_collapse_slowdown():
     normal_duration = t1 - t0
     logging.info('normal collapse took %f', normal_duration)
 
-    assert 3 * normal_duration < slow_duration < 10 * normal_duration
+    assert 3 * normal_duration < slow_duration < 20 * normal_duration

--- a/extension/test/server/left/test_concurrent_collapse_fails.py
+++ b/extension/test/server/left/test_concurrent_collapse_fails.py
@@ -34,6 +34,9 @@ from nose.tools import *
 def test_concurrent_collapse_fails():
     """ assert only one collapse goes through at any time (eta : 450s) """
     zero = Common.node_names[0]
+    Common.stopOne(zero)
+    Common._getCluster().setCollapseSlowdown(0.3)
+    Common.startOne(zero)
     n = 298765
     logging.info("going to do %i sets to fill tlogs", n)
     Common.iterate_n_times(n, Common.simple_set)


### PR DESCRIPTION
first commit is motivated by http://172.19.49.85/view/arakoon-1.7/job/arakoon-1.7-system-tests-slow-LEFT/lastCompletedBuild/testReport/arakoon_system_tests.server.left/test_collapse_slowdown/test_collapse_slowdown/
second commit is motivated by http://172.19.49.85/view/arakoon-git/job/arakoon-git-system-tests-slow-LEFT/482/testReport/arakoon_system_tests.server.left/test_concurrent_collapse_fails/test_concurrent_collapse_fails/
