### PR TITLE
sprinkle sleep before asserting running nodes

### DIFF
--- a/pylabs/test/server/right/system_tests_preferred_masters.py
+++ b/pylabs/test/server/right/system_tests_preferred_masters.py
@@ -75,6 +75,7 @@ def test_preferred_masters():
 
     # Launch cluster and wait until it's up-and-running
     cluster.start()
+    time.sleep(1.0)
     Common.assert_running_nodes(5)
 
     time.sleep(4.0 * Common.lease_duration)


### PR DESCRIPTION
http://172.19.49.85/view/arakoon-git/job/arakoon-amplidata-git-system-tests-slow-RIGHT/lastCompletedBuild/testReport/arakoon_system_tests.server.right/system_tests_preferred_masters/test_preferred_masters/
