### PR TITLE
master_dictate: send accept messages to slaves before the master accepts...

### DIFF
--- a/src/paxos/master.ml
+++ b/src/paxos/master.ml
@@ -257,14 +257,14 @@ let master_dictate constants ({mo;v;n;i;lew} as ms) () =
   let sides =
     if null lew
     then
-      [accept_e;
+      [mcast_e;
+       accept_e;
        start_e;
-       mcast_e;
        log_e;
       ]
     else
-      [accept_e;
-       mcast_e;
+      [mcast_e;
+       accept_e;
        log_e;
       ]
   in


### PR DESCRIPTION
... (and fsyncs) the paxos value

(this removes the fsync on the master from the critical path)

Ok on CI
