### PR TITLE
more aggressive election timeout when in stable master state

### DIFF
--- a/src/paxos/master.ml
+++ b/src/paxos/master.ml
@@ -281,5 +281,5 @@ let master_dictate constants ms () =
        mcast_e;
        accept_e;
       ] in
-  start_election_timeout constants n i >>= fun () ->
+  start_election_timeout ~from_master:true constants n i >>= fun () ->
   Fsm.return ~sides (Accepteds_check_done (ms, ballot))

--- a/src/paxos/multi_paxos.ml
+++ b/src/paxos/multi_paxos.ml
@@ -269,8 +269,13 @@ let start_lease_expiration_thread (type s) ?(immediate_lease_expiration=false) c
     Lwt.return () in
   inner ()
 
-let start_election_timeout constants n i =
-  let sleep_sec = float_of_int (constants.lease_expiration) /. 2.0 in
+let start_election_timeout ?(from_master=false) constants n i =
+  let sleep_sec =
+    if from_master
+    then
+      float_of_int (constants.lease_expiration) /. 4.0
+    else
+      float_of_int (constants.lease_expiration) /. 2.0 in
   let () = match constants.election_timeout with
     | None ->
       begin


### PR DESCRIPTION
have a look at the logs related to http://172.19.49.85/view/arakoon-1.7/job/arakoon-1.7-system-tests-slow-RIGHT/244/testReport/junit/arakoon_system_tests.server.right/system_tests_long_right/test_drop_master/
