### PR TITLE
prevent drop master test from failing with NoMaster because in the

### DIFF
--- a/pylabs/test/server/right/system_tests_long_right.py
+++ b/pylabs/test/server/right/system_tests_long_right.py
@@ -332,17 +332,21 @@ def drop_master(n):
 
 @Common.with_custom_setup( Common.setup_3_nodes, Common.basic_teardown)
 def test_drop_master():
-    Common.stopOne( Common.node_names[0] )
+    m = Common.get_client().whoMaster()
+    zero = Common.node_names[0]
+    s = zero if m <> zero else Common.node_names[1]
+    Common.stopOne(s)
     n = 20
     drop_master(n)
-"""    drop_masters = lambda : drop_master(n)
-    Common.create_and_wait_for_threads ( 1, 1, drop_masters, n*8*3 )"""
 
 
 def _test_drop_master_with_load_(client):
     global busy, excs
 
-    Common.stopOne( Common.node_names[0] )
+    m = Common.get_client().whoMaster()
+    zero = Common.node_names[0]
+    s = zero if m <> zero else Common.node_names[1]
+    Common.stopOne(s)
     n = 40
 
     busy = True


### PR DESCRIPTION
beginning the active master was stopped
