### PR TITLE
Master lease

### DIFF
--- a/pylabs/test/server/quick/system_tests_basic.py
+++ b/pylabs/test/server/quick/system_tests_basic.py
@@ -104,7 +104,7 @@ def test_max_value_size_tinkering ():
     C.assert_running_nodes(1)
     client = C.get_client()
     assert_raises (X.arakoon_client.ArakoonException, client.set, key, value)
-    
+
 
 @C.with_custom_setup(C.setup_1_node,C.basic_teardown)
 def test_marker_presence_required ():
@@ -385,7 +385,7 @@ def test_consistency():
     m = client.get_txid()
     logging.debug("m = %s", m)
     assert_equals(str(m).find("AtLeast"),0)
-    time.sleep(5)
+    client.nop()
     client.setConsistency(m)
     v = client.get('x')
     assert_equals(v,'X')

--- a/src/lib/std.ml
+++ b/src/lib/std.ml
@@ -385,3 +385,9 @@ module Map = struct
 end
 
 type 'a counted_list = (int * 'a list)
+
+module Int64 = struct
+  include Int64
+  module C = CompareLib.Default(Int64)
+  include C
+end

--- a/src/msg/message.ml
+++ b/src/msg/message.ml
@@ -18,7 +18,7 @@ limitations under the License.
 
 module Message = struct
 
-  type t = {kind:string; payload:string} (* primitive, bug suffices *)
+  type t = {kind:string; payload:string} (* primitive, but suffices *)
 
 
   let create kind payload =

--- a/src/msg/messaging.ml
+++ b/src/msg/messaging.ml
@@ -26,13 +26,13 @@ type address = (string * int)
 
 class type messaging = object
   method register_receivers: (id * address) list -> unit
-  method send_message: Message.t -> source:id -> target:id -> unit Lwt.t
-  method recv_message: target:id -> (Message.t * id) Lwt.t
+  method send_message: Message.t -> source:id -> ?sub_target:string -> target:id -> unit Lwt.t
+  method recv_message: ?sub_target:string -> target:id -> (Message.t * id) Lwt.t
   method expect_reachable: target: id -> bool
   method run :
     ?setup_callback:(unit -> unit Lwt.t) ->
     ?teardown_callback:(unit -> unit Lwt.t) ->
     ?ssl_context:([> `Server ] Typed_ssl.t) ->
     unit -> unit Lwt.t
-  method get_buffer: id -> (Message.t * id) Lwt_buffer.t
+  method get_buffer: ?sub_target:string -> id -> (Message.t * id) Lwt_buffer.t
 end

--- a/src/msg/tcp_messaging.ml
+++ b/src/msg/tcp_messaging.ml
@@ -359,7 +359,7 @@ class tcp_messaging
         let (source:id) = Llio.string_from buffer in
         let target      = Llio.string_from buffer in
         let msg         = Message.from_buffer buffer in
-        Logger.debug_f_ "message from %s for %s" source target >>= fun () ->
+        (* Logger.debug_f_ "message from %s for %s" source target >>= fun () -> *)
         if drop_it msg source target then Lwt.return b1
         else
           begin

--- a/src/msg/tcp_messaging.ml
+++ b/src/msg/tcp_messaging.ml
@@ -83,9 +83,18 @@ class tcp_messaging
 
     method register_receivers mapping = List.iter (fun (id,address) -> self # _register_receiver id address) mapping
 
+    method private _target' sub_target target =
+      match sub_target with
+        | None -> target
+        | Some sub -> Printf.sprintf "%s\n%s" target sub
 
     method private _get_target_addresses ~target =
-      try Some (Hashtbl.find _id2address target)
+      let target' =
+        try
+          let index = String.index target '\n' in
+          String.sub target 0 index
+        with Not_found -> target in
+      try Some (Hashtbl.find _id2address target')
       with Not_found -> None
 
 
@@ -114,14 +123,13 @@ class tcp_messaging
         let () = Hashtbl.add _outgoing target fresh in
         fresh
 
-    method send_message m ~source ~target =
+    method send_message m ~source ?sub_target ~target =
       let tq = self # _get_send_q ~target in
-      Lwt_buffer.add (source, target, m) tq
+      Lwt_buffer.add (source, target, sub_target, m) tq
 
-
-
-    method private get_buffer (target:id) =
-      try Hashtbl.find _qs target
+    method private get_buffer ?sub_target (target:id) =
+      let target' = self # _target' sub_target target in
+      try Hashtbl.find _qs target'
       with | Not_found ->
         begin
           let tq =
@@ -132,8 +140,8 @@ class tcp_messaging
           tq
         end
 
-    method recv_message ~target =
-      let q = self # get_buffer target in
+    method recv_message ?sub_target ~target =
+      let q = self # get_buffer ?sub_target target in
       Lwt_buffer.take q
 
     method private _establish_connection address =
@@ -167,7 +175,7 @@ class tcp_messaging
 
     method private _make_sender_loop target target_q =
       let rec _loop_for_q () =
-        Lwt_buffer.take target_q >>= fun (source, target, msg) ->
+        Lwt_buffer.take target_q >>= fun (source, target, sub_target, msg) ->
         let rr_o = self # _get_target_addresses ~target in
         begin
           match rr_o with

--- a/src/node/simple_store.ml
+++ b/src/node/simple_store.ml
@@ -26,8 +26,8 @@ let __j_key = "*j"
 let __interval_key = "*interval"
 let __routing_key = "*routing"
 let __master_key  = "*master"
-let __lease_key = "*lease"
-let __lease_key2 = "*lease2"
+(* let __lease_key = "*lease" *)
+(* let __lease_key2 = "*lease2" *)
 let __prefix = "@"
 let __adminprefix="*"
 

--- a/src/node/store.ml
+++ b/src/node/store.ml
@@ -281,14 +281,8 @@ struct
         Lwt.return ())
 
   let set_master_no_inc store master lease_start =
-    if quiesced store
-    then
-      begin
-        store.master <- Some (master, lease_start);
-        Lwt.return ()
-      end
-    else
-      S.with_transaction store.s (fun tx -> set_master store tx master lease_start)
+    store.master <- Some (master, lease_start);
+    Lwt.return ()
 
   let clear_self_master store me =
     match store.master with

--- a/src/node/store.ml
+++ b/src/node/store.ml
@@ -129,17 +129,7 @@ struct
   let _master store =
     try
       let m = S.get store __master_key in
-      let ls =
-        try
-          (* first try new key with more accurate storage *)
-          let ls_buff = S.get store __lease_key2 in
-          let ls = Llio.float_from (Llio.make_buffer ls_buff 0) in
-          ls
-        with Not_found ->
-          (* fallback to old more coarse grained lease period *)
-          let ls_buff = S.get store __lease_key in
-          let ls  = Llio.int64_from (Llio.make_buffer ls_buff 0) in
-          (Int64.to_float ls) +. 1. in
+      let ls = Unix.gettimeofday () in
       Some (m,ls)
     with Not_found ->
       None
@@ -273,10 +263,6 @@ struct
   let set_master store tx master lease_start =
     _wrap_exception store "SET_MASTER" Server.FOOBAR (fun () ->
         S.set store.s tx __master_key master;
-        let buffer = Buffer.create 8 in
-        let () = Llio.float_to buffer lease_start in
-        let lease = Buffer.contents buffer in
-        S.set store.s tx __lease_key2 lease;
         store.master <- Some (master, lease_start);
         Lwt.return ())
 

--- a/src/paxos/master.ml
+++ b/src/paxos/master.ml
@@ -141,6 +141,7 @@ let stable_master (type s) constants ((n,new_i, lease_expire_waiters) as current
           if diff < (Sn.of_int 5) && constants.is_alive p
           then
             begin
+              constants.drop_master ();
               let log_e = ELog (fun () -> Printf.sprintf "stable_master: handover to %s" p) in
               Fsm.return ~sides:[log_e] (Stable_master current_state)
             end

--- a/src/paxos/master.ml
+++ b/src/paxos/master.ml
@@ -44,7 +44,7 @@ let master_consensus (type s) constants {mo;v;n;i; lew} () =
         | Value.Vm _ ->
           let event = Multi_paxos.FromClient [(Update.Nop, fun _ -> Lwt.return ())] in
           Lwt.ignore_result (constants.inject_event event);
-          constants.kick ();
+          constants.renew_lease ();
           Lwt.return ()
         | _ ->
           begin
@@ -250,6 +250,7 @@ let stable_master (type s) constants ((n,new_i, lease_expire_waiters) as current
     | Unquiesce -> Lwt.fail (Failure "Unexpected unquiesce request while running as")
 
     | DropMaster (sleep, awake) ->
+      constants.drop_master ();
       let state' = (n,new_i, (sleep, awake) :: lease_expire_waiters) in
       Fsm.return (Stable_master state')
 

--- a/src/paxos/master.ml
+++ b/src/paxos/master.ml
@@ -44,6 +44,7 @@ let master_consensus (type s) constants {mo;v;n;i; lew} () =
         | Value.Vm _ ->
           let event = Multi_paxos.FromClient [(Update.Nop, fun _ -> Lwt.return ())] in
           Lwt.ignore_result (constants.inject_event event);
+          constants.kick ();
           Lwt.return ()
         | _ ->
           begin

--- a/src/paxos/multi_paxos.ml
+++ b/src/paxos/multi_paxos.ml
@@ -63,7 +63,7 @@ let network_of_messaging (m:messaging) =
   let send msg source target =
     Logger.debug_f_ "%s: sending msg to %s: %s" source target (Mp_msg.MPMessage.string_of msg) >>= fun () ->
     let g = MPMessage.generic_of msg in
-    m # send_message g ~source ~target
+    m # send_message g ~source ?sub_target:None ~target
   in
   let register = m # register_receivers in
   let run () = m # run () in

--- a/src/paxos/multi_paxos.ml
+++ b/src/paxos/multi_paxos.ml
@@ -234,7 +234,13 @@ let start_lease_expiration_thread (type s) ?(immediate_lease_expiration=false) c
         1.1
       else
         0.5 in
-    let sleep_sec = (lease_expiration +. lease_start -. Unix.gettimeofday ()) *. factor in
+    let sleep_sec =
+      let now = Unix.gettimeofday () in
+      if lease_start +. lease_expiration < now
+      then
+        lease_expiration *. factor
+      else
+        (lease_expiration -. (now -. lease_start)) *. factor in
     let t () =
       begin
         Logger.debug_f_ "%s: waiting %2.1f seconds for lease to expire"

--- a/src/paxos/multi_paxos.ml
+++ b/src/paxos/multi_paxos.ml
@@ -132,7 +132,8 @@ type 'a constants =
    mutable election_timeout : (Sn.t * Sn.t * float) option;
    mutable lease_expiration_id : int;
    mutable respect_run_master : (string * float) option;
-   kick : unit -> unit;
+   renew_lease : unit -> unit;
+   drop_master : unit -> unit;
   }
 
 let am_forced_master constants me =
@@ -149,7 +150,7 @@ let make (type s) ~catchup_tls_ctx me is_learner others send get_value
       on_accept on_consensus on_witness
       last_witnessed quorum_function (master:master) (module S : Store.STORE with type t = s) store tlog_coll
       other_cfgs lease_expiration inject_event is_alive ~cluster_id
-      quiesced stop kick =
+      quiesced stop ~renew_lease ~drop_master =
   {
     me=me;
     is_learner;
@@ -176,7 +177,8 @@ let make (type s) ~catchup_tls_ctx me is_learner others send get_value
     election_timeout = None;
     lease_expiration_id = 0;
     respect_run_master = None;
-    kick;
+    drop_master;
+    renew_lease;
   }
 
 let mcast constants msg =

--- a/src/paxos/multi_paxos.ml
+++ b/src/paxos/multi_paxos.ml
@@ -132,6 +132,7 @@ type 'a constants =
    mutable election_timeout : (Sn.t * Sn.t * float) option;
    mutable lease_expiration_id : int;
    mutable respect_run_master : (string * float) option;
+   kick : unit -> unit;
   }
 
 let am_forced_master constants me =
@@ -148,7 +149,7 @@ let make (type s) ~catchup_tls_ctx me is_learner others send get_value
       on_accept on_consensus on_witness
       last_witnessed quorum_function (master:master) (module S : Store.STORE with type t = s) store tlog_coll
       other_cfgs lease_expiration inject_event is_alive ~cluster_id
-      quiesced stop =
+      quiesced stop kick =
   {
     me=me;
     is_learner;
@@ -175,6 +176,7 @@ let make (type s) ~catchup_tls_ctx me is_learner others send get_value
     election_timeout = None;
     lease_expiration_id = 0;
     respect_run_master = None;
+    kick;
   }
 
 let mcast constants msg =

--- a/src/paxos/multi_paxos.ml
+++ b/src/paxos/multi_paxos.ml
@@ -234,7 +234,7 @@ let start_lease_expiration_thread (type s) ?(immediate_lease_expiration=false) c
         1.1
       else
         0.5 in
-    let sleep_sec = lease_expiration *. factor in
+    let sleep_sec = (lease_expiration +. lease_start -. Unix.gettimeofday ()) *. factor in
     let t () =
       begin
         Logger.debug_f_ "%s: waiting %2.1f seconds for lease to expire"

--- a/src/paxos/multi_paxos_fsm.ml
+++ b/src/paxos/multi_paxos_fsm.ml
@@ -74,15 +74,15 @@ let promises_check_done constants state () =
   *)
   let me = constants.me in
   let nnones, v_s = v_lims in
-  let bv,bf,number_of_updates =
+  let bv,bf =
     begin
       match v_s with
-        | [] ->  (Value.create_master_value (me, 0.0), 0, 1)
+        | [] ->  (Value.create_master_value (me, 0.0), 0)
         | hd::tl ->
           let bv, bf = hd in
           if Value.is_master_set bv
-          then (Value.create_master_value (me, 0.0), bf, 1)
-          else bv, bf , List.length (Value.updates_from_value bv)
+          then (Value.create_master_value (me, 0.0), bf)
+          else bv, bf
 
     end in
   let nnodes = List.length constants.others + 1 in

--- a/src/paxos/multi_paxos_test.ml
+++ b/src/paxos/multi_paxos_test.ml
@@ -321,7 +321,7 @@ let build_tcp () =
     (fun _ _ _ -> false) Node_cfg.default_max_buffer_size ~stop:(ref false)
   in
   let network = network_of_messaging m in
-  m # get_buffer, network
+  m # get_buffer ?sub_target:None, network
 
 
 

--- a/src/paxos/multi_paxos_test.ml
+++ b/src/paxos/multi_paxos_test.ml
@@ -88,6 +88,7 @@ let test_generic network_factory n_nodes () =
               lease_expiration_id = 0;
               respect_run_master = None;
               catchup_tls_ctx = None;
+              kick = fun () -> ();
              }
   in
   let all_happy = build_names (n_nodes -1) in
@@ -263,6 +264,7 @@ let test_master_loop network_factory ()  =
                    lease_expiration_id = 0;
                    respect_run_master = None;
                    catchup_tls_ctx = None;
+                   kick = fun () -> ();
                   } in
   let continue = ref 2 in
   let c0_t () =
@@ -391,6 +393,7 @@ let test_simulation filters () =
     lease_expiration_id = 0;
     respect_run_master = None;
     catchup_tls_ctx = None;
+    kick = fun () -> ();
   } in
   let c0_t () =
     let expected prev_key key =

--- a/src/paxos/multi_paxos_test.ml
+++ b/src/paxos/multi_paxos_test.ml
@@ -88,7 +88,8 @@ let test_generic network_factory n_nodes () =
               lease_expiration_id = 0;
               respect_run_master = None;
               catchup_tls_ctx = None;
-              kick = fun () -> ();
+              renew_lease = (fun () -> ());
+              drop_master = (fun () -> ());
              }
   in
   let all_happy = build_names (n_nodes -1) in
@@ -264,7 +265,8 @@ let test_master_loop network_factory ()  =
                    lease_expiration_id = 0;
                    respect_run_master = None;
                    catchup_tls_ctx = None;
-                   kick = fun () -> ();
+                   renew_lease = (fun () -> ());
+                   drop_master = (fun () -> ());
                   } in
   let continue = ref 2 in
   let c0_t () =
@@ -393,7 +395,8 @@ let test_simulation filters () =
     lease_expiration_id = 0;
     respect_run_master = None;
     catchup_tls_ctx = None;
-    kick = fun () -> ();
+    renew_lease = (fun () -> ());
+    drop_master = (fun () -> ());
   } in
   let c0_t () =
     let expected prev_key key =

--- a/src/system/single.ml
+++ b/src/system/single.ml
@@ -608,6 +608,21 @@ let assert_exists3 tpl =
   _start "assert_exists3" >>= fun () ->
   _with_master tpl _assert_exists3
 
+let test_renew_lease tpl =
+  _with_master
+    tpl
+    (fun client ->
+     Mem_tlogcollection.delay := (Some 10.);
+     Lwt.finalize
+       (fun () ->
+        client # set "k" "v" >>= fun () ->
+        client # get "k" >>= fun v ->
+        Lwt.return ())
+       (fun () ->
+        Mem_tlogcollection.delay := None;
+        Lwt.return ())
+    )
+
 let _node_name tn n = Printf.sprintf "%s_%i" tn n
 
 let setup make_master tn base () =
@@ -652,7 +667,8 @@ let make_suite base name w =
       make_el "assert_exists2"   (base + 1200) assert_exists2;
       make_el "assert_exists3"   (base + 1300) assert_exists3;
       make_el "trivial_master6"  (base + 1400) trivial_master6;
-      make_el "replace"          (base + 1500) replace
+      make_el "replace"          (base + 1500) replace;
+      make_el "test_renew_lease" (base + 1600) test_renew_lease;
     ]
 
 let force_master =

--- a/src/tlog/mem_tlogcollection.ml
+++ b/src/tlog/mem_tlogcollection.ml
@@ -20,6 +20,7 @@ open Tlogcollection
 open Tlogcommon
 open Lwt
 
+let delay = ref None
 
 class mem_tlog_collection name =
   object (self: #tlog_collection)
@@ -79,7 +80,11 @@ class mem_tlog_collection name =
       let entry = Entry.make i v 0L marker in
       let () = data <- entry::data in
       let () = last_entry <- (Some entry) in
-      Lwt.return ()
+      match !delay with
+      | None ->
+         Lwt.return ()
+      | Some d ->
+         Lwt_unix.sleep (Random.float d)
 
     method log_value i v = self #log_value_explicit i v false None
 


### PR DESCRIPTION
I think this works as intended (see http://jira.incubaid.com/browse/ARAKOON-468 ) .. but I want some comments about how to organize it.

I'm not really satisfied with the RenewLease module in node_main which allows creating a few `unit Lwt.t`s which should then be ran.
I was thinking maybe these loops should be written as 'actors' ?
(I could add a few helpers which allow easily defining a few actors)
Instead of returning the unit Lwt.t these could be `Lwt.ignore_result`ed, maybe that's cleaner?

I could move the RenewLease module to another file (probably somewhere in the /paxos dir).

Feedback wanted.
