### PR TITLE
fix __tainted_fsync_tlog_dir typo

### DIFF
--- a/pylabs/test/server/system_tests_common.py
+++ b/pylabs/test/server/system_tests_common.py
@@ -679,7 +679,7 @@ def setup_n_nodes_base(c_id, node_names, force_master,
     config = cluster._getConfigFile()
     for i in range (n):
         nodeName = node_names[ i ]
-        config.set(nodeName, '__tained_fsync_tlog_dir', 'false')
+        config.set(nodeName, '__tainted_fsync_tlog_dir', 'false')
 
     #
     #

--- a/src/node/node_cfg.ml
+++ b/src/node/node_cfg.ml
@@ -440,7 +440,7 @@ module Node_cfg = struct
     let _fsync_tlog_dir = Ini.get
                             inifile
                             node_name
-                            "__tained_fsync_tlog_dir"
+                            "__tainted_fsync_tlog_dir"
                             Ini.p_bool
                             (Ini.default true) in
     let targets =


### PR DESCRIPTION
Tests are still running for this one, but the change is so trivial it's almost impossible I made a mistake :)
