### PR TITLE
Remove custom GC configuration

### DIFF
--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -19,7 +19,6 @@ open Tcp_messaging
 open Update
 open Lwt
 open Lwt_buffer
-open Gc
 open Master_type
 open Client_cfg
 open Statistics
@@ -347,17 +346,6 @@ let _main_2 (type s)
       make_config get_snapshot_name ~name
       ~daemonize ~catchup_only stop : int Lwt.t =
   Lwt_io.set_default_buffer_size 32768;
-  let control  = {
-    minor_heap_size = 32 * 1024;
-    major_heap_increment = 124 * 1024;
-    space_overhead = 80;
-    verbose = 0;
-    max_overhead = 0;
-    stack_limit = 256 * 1024;
-    allocation_policy = 1;
-  }
-  in
-  Gc.set control;
   let cluster_cfg = make_config () in
   let cfgs = cluster_cfg.cfgs in
   let me, others = _split name cfgs in


### PR DESCRIPTION
During some non-real-world benchmarking (single-node cluster, `fsync`
disabled, running in `tmpfs`) it turned out the custom GC configuration
as set up by Arakoon has a non-negligible performance impact: the `set`
scenario of the built-in benchmark goes from +- 115s to +- 93s.

It looks like the default GC settings (of OCaml 4.01.0) are better
suited for the Arakoon workload.

Next to this, the custom settings removed the ability to set
site-specific configurations using `OCAMLRUNPARAM`.
