### PR TITLE
Regularly dump TCP_INFO statistics of outgoing connections

### DIFF
--- a/src/libcutil.clib
+++ b/src/libcutil.clib
@@ -1,3 +1,4 @@
 arakoon_crc32c.o
 bsd_crc32c.o
 arakoon_limits.o
+tcp_info_stubs.o

--- a/src/msg/tcp_messaging.ml
+++ b/src/msg/tcp_messaging.ml
@@ -20,7 +20,7 @@ open Lwt
 open Lwt_buffer
 open Network
 
-type connection = Lwt_io.input_channel * Lwt_io.output_channel
+type connection = Lwt_unix.file_descr * Lwt_io.input_channel * Lwt_io.output_channel
 
 let section =
   let s = Logger.Section.make "tcp_messaging" in
@@ -44,6 +44,24 @@ module RR = struct
   let fold f a0 t = List.fold_left f a0 t.addresses
 end
 
+let run_report connections =
+  let rec loop () =
+    let go = Hashtbl.fold (fun (addr, port) (socket, _, _) rest -> fun () ->
+      begin try
+        let info = Tcp_info.tcp_info (Lwt_unix.unix_file_descr socket) in
+        Logger.info_f_ "TCP info for %s:%d: %s" addr port (Tcp_info.to_string info)
+      with exn ->
+        Logger.error_f_ ~exn "TCP info lookup for %s:%d failed" addr port
+      end >>=
+      rest)
+      connections
+      Lwt.return
+    in
+    go () >>= fun () ->
+    Lwt_unix.sleep 60.0 >>=
+    loop
+  in
+  loop ()
 
 class tcp_messaging
   ?(timeout=60.0)
@@ -133,13 +151,13 @@ class tcp_messaging
       >>= fun () ->
       Lwt_unix.with_timeout timeout
         (fun () ->__open_connection ?ssl_context socket_address)
-      >>= fun (ic,oc) ->
+      >>= fun (socket, ic, oc) ->
       Llio.output_int64 oc _MAGIC >>= fun () ->
       Llio.output_int oc _VERSION >>= fun () ->
       Llio.output_string oc my_cookie >>= fun () ->
       Llio.output_string oc my_ip >>= fun () ->
       Llio.output_int oc my_port  >>= fun () ->
-      Lwt.return (ic,oc)
+      Lwt.return (socket, ic, oc)
     (* open_connection can also fail with Unix.Unix_error (63, "connect",_)
        on local host *)
 
@@ -170,7 +188,7 @@ class tcp_messaging
                   timeout
                   (fun () ->
                    self # _get_connection addresses >>= fun connection ->
-                   let ic,oc = connection in
+                   let _, ic, oc = connection in
                    let pickled = self # _pickle source target msg in
                    Llio.output_string oc pickled >>= fun () ->
                    Lwt_io.flush oc)
@@ -259,7 +277,7 @@ class tcp_messaging
         begin
           let conn = Hashtbl.find _connections address in
           Logger.debug_ "found connection, closing it" >>= fun () ->
-          let ic,oc = conn in
+          let _, ic, oc = conn in
           (* something with conn *)
           Lwt.catch
             (fun () ->
@@ -391,6 +409,7 @@ class tcp_messaging
         Lwt.join sts
       in
       _running <- true;
+      _my_threads <- (run_report _connections) :: _my_threads;
       Lwt_condition.broadcast _running_c ();
       servers_t () >>= fun () ->
       Logger.info_f_ "tcp_messaging %s: end of run" me >>= fun () ->

--- a/src/nursery/nursery.ml
+++ b/src/nursery/nursery.ml
@@ -31,7 +31,7 @@ let try_connect (ips, port) =
   Lwt.catch
     (fun () ->
        let sa = Network.make_address ips port in
-       Network.__open_connection sa >>= fun (ic,oc) ->
+       Network.__open_connection sa >>= fun (_, ic, oc) ->
        let r = Some (ic,oc) in
        Lwt.return r
     )

--- a/src/tools/network.ml
+++ b/src/tools/network.ml
@@ -55,7 +55,7 @@ let __open_connection ?(ssl_context : [> `Client ] Typed_ssl.t option)
          | None ->
              let ic = Lwt_io.of_fd ~mode:Lwt_io.input  socket
              and oc = Lwt_io.of_fd ~mode:Lwt_io.output socket in
-             Lwt.return (ic,oc)
+             Lwt.return (socket, ic, oc)
          | Some ctx ->
              Typed_ssl.Lwt.ssl_connect socket ctx >>= fun (s, lwt_s) ->
              let cert = Ssl.get_certificate s in
@@ -68,7 +68,7 @@ let __open_connection ?(ssl_context : [> `Client ] Typed_ssl.t option)
                peer_s (Ssl.get_cipher_description cipher) >>= fun () ->
              let ic = Lwt_ssl.in_channel_of_descr lwt_s
              and oc = Lwt_ssl.out_channel_of_descr lwt_s in
-             Lwt.return (ic, oc)
+             Lwt.return (socket, ic, oc)
        )
     (fun exn ->
        Logger.info_f_ ~exn "__open_connection to %s failed" (a2s socket_address)

--- a/src/tools/tcp_info.ml
+++ b/src/tools/tcp_info.ml
@@ -1,0 +1,69 @@
+(*
+Copyright (2010-2014) INCUBAID BVBA
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*)
+
+type u_int8_t = int
+type u_int32_t = int
+
+type t = { state : u_int8_t
+         ; ca_state : u_int8_t
+         ; retransmits : u_int8_t
+         ; probes : u_int8_t
+         ; backoff : u_int8_t
+         ; options : u_int8_t
+         ; snd_wscale : u_int8_t
+         ; rcv_wscale : u_int8_t
+
+         ; rto : u_int32_t
+         ; ato : u_int32_t
+         ; snd_mss : u_int32_t
+         ; rcv_mss : u_int32_t
+
+         ; unacked : u_int32_t
+         ; sacked : u_int32_t
+         ; lost : u_int32_t
+         ; retrans : u_int32_t
+         ; fackets : u_int32_t
+
+         ; last_data_sent : u_int32_t
+         ; last_ack_sent : u_int32_t
+         ; last_data_recv : u_int32_t
+         ; last_ack_recv : u_int32_t
+
+         ; pmtu : u_int32_t
+         ; rcv_ssthresh : u_int32_t
+         ; rtt : u_int32_t
+         ; rttvar : u_int32_t
+         ; snd_ssthresh : u_int32_t
+         ; snd_cwnd : u_int32_t
+         ; advmss : u_int32_t
+         ; reordering : u_int32_t
+
+         ; rcv_rtt : u_int32_t
+         ; rcv_space : u_int32_t
+
+         ; total_retrans : u_int32_t
+         }
+
+let to_string t =
+  Printf.sprintf "{ state=%d; ca_state=%d; retransmits=%d; probes=%d; backoff=%d; options=%d; snd_wscale=%d; rcv_wscale=%d; rto=%d; ato=%d; snd_mss=%d; rcv_mss=%d; unacked=%d; sacked=%d; lost=%d; retrans=%d; fackets=%d; last_data_sent=%d; last_ack_sent=%d; last_data_recv=%d; last_ack_recv=%d; pmtu=%d; rcv_ssthresh=%d; rtt=%d; rttvar=%d; snd_ssthresh=%d; snd_cwnd=%d; advmss=%d; reordering=%d; rcv_rtt=%d; rcv_space=%d; total_retrans=%d; }"
+    t.state t.ca_state t.retransmits t.probes t.backoff t.options t.snd_wscale
+    t.rcv_wscale t.rto t.ato t.snd_mss t.rcv_mss t.unacked t.sacked t.lost
+    t.retrans t.fackets t.last_data_sent t.last_ack_sent t.last_data_recv
+    t.last_ack_recv t.pmtu t.rcv_ssthresh t.rtt t.rttvar t.snd_ssthresh
+    t.snd_cwnd t.advmss t.reordering t.rcv_rtt t.rcv_space t.total_retrans
+
+type socket = Unix.file_descr
+external tcp_info : socket -> t = "arakoon_tcp_info"

--- a/src/tools/tcp_info_stubs.c
+++ b/src/tools/tcp_info_stubs.c
@@ -1,0 +1,97 @@
+/*
+  Copyright (2010-2014) INCUBAID BVBA
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include <assert.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/tcp.h>
+
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/unixsupport.h>
+
+value arakoon_tcp_info(value fd) {
+        CAMLparam1(fd);
+        CAMLlocal1(t);
+
+        int c_fd = 0, ret = -1, idx = 0;
+        socklen_t len = 0;
+        struct tcp_info info;
+
+        c_fd = Int_val(fd);
+        len = sizeof(info);
+
+        ret = getsockopt(c_fd, SOL_TCP, TCP_INFO, &info, &len);
+
+        if(ret == -1) {
+                uerror("getsockopt", Nothing);
+        }
+
+#define NUM_FIELDS 32
+
+        t = caml_alloc(NUM_FIELDS, 0);
+
+#define STORE(field) \
+        do { \
+                assert(idx < NUM_FIELDS); \
+                Store_field(t, idx, Val_int(info.tcpi_ ##field )); \
+                idx++; \
+        } while(0)
+        STORE(state);
+        STORE(ca_state);
+        STORE(retransmits);
+        STORE(probes);
+        STORE(backoff);
+        STORE(options);
+        STORE(snd_wscale);
+        STORE(rcv_wscale);
+
+        STORE(rto);
+        STORE(ato);
+        STORE(snd_mss);
+        STORE(rcv_mss);
+
+        STORE(unacked);
+        STORE(sacked);
+        STORE(lost);
+        STORE(retrans);
+        STORE(fackets);
+
+        STORE(last_data_sent);
+        STORE(last_ack_sent);
+        STORE(last_data_recv);
+        STORE(last_ack_recv);
+
+        STORE(pmtu);
+        STORE(rcv_ssthresh);
+        STORE(rtt);
+        STORE(rttvar);
+        STORE(snd_ssthresh);
+        STORE(snd_cwnd);
+        STORE(advmss);
+        STORE(reordering);
+
+        STORE(rcv_rtt);
+        STORE(rcv_space);
+
+        STORE(total_retrans);
+
+        assert(idx == NUM_FIELDS);
+
+        CAMLreturn(t);
+}


### PR DESCRIPTION
Backport from PR #401 to 1.7.

(cherry picked from commit b88bd91447cb143ae5a6a08ca54a9d5166314d6e)

Conflicts:
    src/libcutil.clib

Closes #401
