### PR TITLE
Add TLS version & cipher list configuration

### DIFF
--- a/cfg/arakoon.ini
+++ b/cfg/arakoon.ini
@@ -53,6 +53,19 @@ cluster_id = ricky
 # configured with tls_ca_cert)
 #
 # tls_service_validate_peer = false
+#
+# Use a specific TLS version (for backwards compatibility, 1.0 is the default).
+# Valid values are '1.0', '1.1' and '1.2'.
+#
+# tls_version = 1.0
+#
+# Select a specific set of enabled ciphers
+# See `man 1 ciphers` and `man 3 SSL_set_cipher_list` for documentation for
+# this value, as well as how unknown settings etc. are handled.
+# The default is to set no specific cipher list, i.e. rely on the default
+# provided by the SSL library on the system.
+#
+# tls_cipher_list =
 
 [default_log_config]
 # available levels are: debug info notice warning error fatal

--- a/doc/tls.rst
+++ b/doc/tls.rst
@@ -35,6 +35,21 @@ When connecting to another node, the node certificate will be requested on both
 sides and validated against the CA certificate. Self-signed certificated
 without a shared CA can't be used.
 
+Next to the configuration settings listed above, 2 more settings are available
+which influence TLS communication:
+
+*global.tls_version*
+    Configure a specific TLS version to use. Valid values are ``1.0``, ``1.1``
+    and ``1.2``.
+    For backwards compatibility, ``1.0`` is the default.
+
+*global.tls_cipher_list*
+    Configure a specific TLS cipher list. See ``man 1 ciphers`` and ``man 3
+    SSL_set_cipher_list`` for more documentation about the meaning of this
+    string, how unknown settings are handled, etc.
+    The default is to set no specific cipher list, i.e. use the default setting
+    as used by your system SSL library.
+
 Configuring client TLS communication
 ------------------------------------
 Once inter-node TLS communication is configured and working, nodes can be
@@ -52,6 +67,9 @@ configuration, clients connecting to nodes are required to provide a certificate
 upon connection, which will be validated by the node against the CA certificate.
 If a client fails to provide a certificate, or this is not signed by the CA, the
 connection will be rejected.
+
+The *global.tls_version* and *global.tls_cipher_list* settings are also
+applicable to client connections.
 
 Using the CLI interface
 -----------------------
@@ -71,3 +89,7 @@ In case a client certificate is required (when
 *global.tls_service_validate_peer* is used), the *-tls-cert* and *-tls-key*
 options should be used, both pointing to the certificate & key files to be used
 when connecting.
+
+To select a specific TLS version, the *-tls-version* option should be used.
+Valid values are ``1.0``, ``1.1`` and ``1.2``. For backwards compatibility, this
+defaults to ``1.0``.

--- a/jenkins/base/008_install_dev_env.sh
+++ b/jenkins/base/008_install_dev_env.sh
@@ -7,7 +7,7 @@ opam switch 4.01.0
 eval `opam config env`
 
 opam update -y
-opam install -y ssl
+opam install -y "ssl.0.4.7"
 opam install -y conf-libev
 opam install -y camlbz2
 opam install -y snappy

--- a/jenkins/base/seed
+++ b/jenkins/base/seed
@@ -1,1 +1,1 @@
-arakoon-1.x-ubuntu-12.10-quantal-20140310
+arakoon-1.x-ubuntu-12.10-quantal-20140617

--- a/jenkins/seed
+++ b/jenkins/seed
@@ -1,1 +1,1 @@
-arakoon-1.x-qbase3-ubuntu-12.10-quantal-20140310
+arakoon-1.x-qbase3-ubuntu-12.10-quantal-20140617

--- a/src/client/python/ArakoonProtocol.py
+++ b/src/client/python/ArakoonProtocol.py
@@ -56,6 +56,12 @@ class ArakoonClientConfig :
                   "mySecondNode" :(["127.0.0.1"], 5000 ),
                   "myThirdNode"  :(["127.0.0.1","10.0.0.1"], 6000 )] })
 
+        Note: This client package only supports TLSv1 when connecting to nodes,
+        due to Python 2.x only supporting this TLS version. If your cluster is
+        configured to use another TLS version, you'll need to use another
+        Arakoon client which can work using a different socket interface which
+        supports different TLS versions.
+
         @type clusterId: string
         @param clusterId: name of the cluster
         @type nodes: dict

--- a/src/main/main.ml
+++ b/src/main/main.ml
@@ -188,6 +188,7 @@ let main () =
   and tls_ca_cert = ref ""
   and tls_cert = ref ""
   and tls_key = ref ""
+  and tls_version = ref "1.0"
   and force = ref false
   and in_place = ref false
   and archive_type = ref ".tlf"
@@ -377,6 +378,7 @@ let main () =
     ("-tls-ca-cert", Arg.Set_string tls_ca_cert, "<path> TLS CA certificate");
     ("-tls-cert", Arg.Set_string tls_cert, "<path> Certificate to use for TLS connections");
     ("-tls-key", Arg.Set_string tls_key, "<path> Key to use for TLS connections");
+    ("-tls-version", Arg.Set_string tls_version, "<[1.0]|1.1|1.2> TLS version to use for connections");
     ("--range-entries", Arg.Tuple [set_laction RANGE_ENTRIES;],
      "list entries within range");
     ("--rev-range-entries", Arg.Tuple [set_laction REV_RANGE_ENTRIES;],
@@ -479,9 +481,20 @@ let main () =
   let tls =
     if !tls_ca_cert = ""
       then None
-      else if !tls_cert = ""
-        then Some (!tls_ca_cert, None)
-        else Some (!tls_ca_cert, Some (!tls_cert, !tls_key))
+      else begin
+        let ca_cert = !tls_ca_cert
+        and protocol = match !tls_version with
+          | "1.0" -> Ssl.TLSv1
+          | "1.1" -> Ssl.TLSv1_1
+          | "1.2" -> Ssl.TLSv1_2
+          | _ -> failwith "Invalid \"tls-version\" value"
+        and creds = match !tls_cert with
+          | "" -> None
+          | s -> Some (s, !tls_key)
+        in
+        let cfg = Client_main.TLSConfig.make ~ca_cert ~creds ~protocol in
+        Some cfg
+      end
   in
 
   let exit_code =

--- a/src/node/node_cfg.ml
+++ b/src/node/node_cfg.ml
@@ -539,14 +539,17 @@ module Node_cfg = struct
     let get_string_option x = Ini.get inifile node_name x (Ini.p_option Ini.p_string) (Ini.default None) in
     let tls_cert = get_string_option "tls_cert"
     and tls_key = get_string_option "tls_key" in
-    if (tls_cert = None && tls_key <> None) || (tls_cert <> None && tls_key = None)
-      then failwith (Printf.sprintf "%s: both tls_cert and tls_key should be provided" node_name);
     let node_tls =
+      let msg = Printf.sprintf "%s: both tls_cert and tls_key should be provided" node_name in
       match tls_cert with
-        | None -> None
-        | Some cert -> match tls_key with
-            | None -> failwith "Node_cfg: Impossible!"
+        | None -> begin match tls_key with
+            | None -> None
+            | Some _ -> failwith msg
+        end
+        | Some cert -> begin match tls_key with
+            | None -> failwith msg
             | Some key -> Some (TLSConfig.Node.make ~cert ~key)
+        end
     in
     let collapse_slowdown = Ini.get inifile node_name "collapse_slowdown" (Ini.p_option Ini.p_float) (Ini.default None) in
     {node_name;

--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -221,15 +221,17 @@ let only_catchup (type s) (module S : Store.STORE with type t = s) ~tls_ctx ~nam
   try_nodes other_configs
 
 let get_ssl_cert_paths me cluster =
-  match me.tls_cert with
+  match me.node_tls with
     | None -> None
-    | Some tls_cert ->
-        match me.tls_key with
-          | None -> failwith "get_ssl_cert_paths: no tls_key"
-          | Some tls_key ->
-              match cluster.tls_ca_cert with
-                | None -> failwith "get_ssl_cert_paths: no tls_ca_cert"
-                | Some tls_ca_cert -> Some (tls_cert, tls_key, tls_ca_cert)
+    | Some config ->
+        match cluster.tls with
+          | None -> failwith "get_ssl_cert_paths: no tls_ca_cert"
+          | Some config' ->
+              let open Node_cfg in
+              let cert = TLSConfig.Node.cert config
+              and key = TLSConfig.Node.key config
+              and ca_cert = TLSConfig.Cluster.ca_cert config' in
+              Some (cert, key, ca_cert)
 
 let build_ssl_context me cluster =
   match get_ssl_cert_paths me cluster with
@@ -246,7 +248,12 @@ let build_ssl_context me cluster =
         Some ctx
 
 let build_service_ssl_context me cluster =
-  if not cluster.tls_service
+  let open Node_cfg in
+  let tls_service = match cluster.tls with
+    | None -> false
+    | Some config -> TLSConfig.Cluster.service config
+  in
+  if not tls_service
   then None
   else match get_ssl_cert_paths me cluster with
     | None -> failwith "build_service_ssl_context: tls_service but no cert/key paths"
@@ -254,9 +261,12 @@ let build_service_ssl_context me cluster =
         let ctx = Typed_ssl.create_server_context Ssl.TLSv1 in
         Typed_ssl.use_certificate ctx tls_cert tls_key;
         let verify =
-          if cluster.tls_service_validate_peer
-          then [Ssl.Verify_peer; Ssl.Verify_fail_if_no_peer_cert]
-          else []
+          match cluster.tls with
+            | None -> failwith "Node_main: Impossible!"
+            | Some config ->
+                if TLSConfig.Cluster.service_validate_peer config
+                then [Ssl.Verify_peer; Ssl.Verify_fail_if_no_peer_cert]
+                else []
         in
         Typed_ssl.set_verify ctx verify (Some Ssl.client_verify_callback);
         Typed_ssl.set_client_CA_list_from_file ctx tls_ca_cert;
@@ -603,9 +613,12 @@ let _main_2 (type s)
                            election_timeout_buffer)
           in
           let catchup_tls_ctx =
-            if cluster_cfg.tls_service
-              then ssl_context
-              else None
+            match cluster_cfg.tls with
+              | None -> None
+              | Some config ->
+                  if Node_cfg.TLSConfig.Cluster.service config
+                  then ssl_context
+                  else None
           in
           let constants =
             Multi_paxos.make ~catchup_tls_ctx:catchup_tls_ctx my_name

--- a/src/system/startup.ml
+++ b/src/system/startup.ml
@@ -68,8 +68,7 @@ let _make_cfg name n lease_period =
     _fsync_tlog_dir = false;
     is_test = true;
     reporting = 300;
-    tls_cert = None;
-    tls_key = None;
+    node_tls = None;
     collapse_slowdown = None;
   }
 
@@ -152,9 +151,7 @@ let post_failure () =
     client_buffer_capacity = Node_cfg.default_client_buffer_capacity;
     lcnum = 8192;
     ncnum = 4096;
-    tls_ca_cert = None;
-    tls_service = false;
-    tls_service_validate_peer = false;
+    tls = None;
   }
   in
   let get_cfgs () = cluster_cfg in
@@ -214,9 +211,7 @@ let restart_slaves () =
      client_buffer_capacity = Node_cfg.default_client_buffer_capacity;
      lcnum = Node_cfg.default_lcnum;
      ncnum = Node_cfg.default_ncnum;
-     tls_ca_cert = None;
-     tls_service = false;
-     tls_service_validate_peer = false;
+     tls = None;
     }
   in
   let get_cfgs () = cluster_cfg in
@@ -275,9 +270,7 @@ let ahead_master_loses_role () =
      client_buffer_capacity = Node_cfg.default_client_buffer_capacity;
      lcnum = 8192;
      ncnum = 4096;
-     tls_ca_cert = None;
-     tls_service = false;
-     tls_service_validate_peer = false;
+     tls = None;
     }
   in
   let get_cfgs () = cluster_cfg in

--- a/src/tools/typed_ssl.ml
+++ b/src/tools/typed_ssl.ml
@@ -26,6 +26,7 @@ let use_certificate = Ssl.use_certificate
 let set_verify = Ssl.set_verify
 let set_client_CA_list_from_file = Ssl.set_client_CA_list_from_file
 let load_verify_locations = Ssl.load_verify_locations
+let set_cipher_list = Ssl.set_cipher_list
 
 open Lwt
 

--- a/src/tools/typed_ssl.mli
+++ b/src/tools/typed_ssl.mli
@@ -26,6 +26,7 @@ val use_certificate : 'a t -> string -> string -> unit
 val set_verify : 'a t -> Ssl.verify_mode list -> Ssl.verify_callback option -> unit
 val set_client_CA_list_from_file : [> `Server ] t -> string -> unit
 val load_verify_locations : 'a t -> string -> string -> unit
+val set_cipher_list : 'a t -> string -> unit
 
 module Lwt : sig
   val ssl_connect : Lwt_unix.file_descr -> [> `Client ] t -> (Ssl.socket * Lwt_ssl.socket) Lwt.t


### PR DESCRIPTION
These commits add the ability to select a TLS version to use (instead of the hard-coded 1.0), and configure a specific cipher list.

Note: as mentioned in the docstring (changed through one of the commits in this PR), the Python client can't handle any TLS version other than 1.0 due to Python 2.x restrictions.

TODO:
- [x] Extend documentation
- [x] Pass CI (running, `arakoon-git-launcher` 337)
