### PR TITLE
Configure `Ssl` to be silent during certificate chain validation

### DIFF
--- a/src/main/main.ml
+++ b/src/main/main.ml
@@ -143,6 +143,7 @@ let run_some_tests repeat_count filter =
 let main () =
   Ssl_threads.init ();
   Ssl.init ~thread_safe:true ();
+  Ssl.set_client_verify_callback_verbose false;
 
   let _ = Bz2.version in
   let () = Sys.set_signal Sys.sigpipe Sys.Signal_ignore in


### PR DESCRIPTION
This depends on https://github.com/Incubaid/ocaml-ssl/commit/7ae54282f2db8ce88b0bb25284cc0c975900ae73 which should first get into https://github.com/savonet/ocaml-ssl and a subsequent release of the OCaml `ssl` library, so this is not ready for merging yet.
- [x] Get https://github.com/Incubaid/ocaml-ssl/commit/7ae54282f2db8ce88b0bb25284cc0c975900ae73 reviewed
- [x] Send pull-request to https://github.com/savonet/ocaml-ssl
- [ ] Wait for new `ssl` release
- [ ] Wait for new `ssl` version available in https://github.com/ocaml/opam-repository
