### PR TITLE
limits dependencies for plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ install_client:
 	  _build/src/client/arakoon_remote_client.cmi \
           _build/src/plugins/registry.mli \
           _build/src/plugins/registry.cmi \
-          _build/src/tools/llio.mli \
-          _build/src/tools/llio.cmi \
+          _build/src/plugins/plugin_helper.mli \
+          _build/src/plugins/plugin_helper.cmi \
           _build/src/arakoon_client.a
 
 uninstall_client:

--- a/src/plugins/plugin_helper.ml
+++ b/src/plugins/plugin_helper.ml
@@ -1,0 +1,16 @@
+let serialize_string  b s = Llio.string_to b s
+let serialize_hashtbl b f h = Llio.hashtbl_to b f h
+let serialize_string_list b sl = Llio.string_list_to b sl
+
+type input = Llio.buffer
+let make_input s i = Llio.make_buffer s i
+
+let deserialize_string i = Llio.string_from i
+let deserialize_string_list i = Llio.string_list_from i
+let deserialize_hashtbl i f = Llio.hashtbl_from i f
+
+let generic_f f x =
+  let k s = Lwt.ignore_result (f s) in
+  Printf.kprintf k x
+
+let debug_f x = generic_f Client_log.debug x

--- a/src/plugins/plugin_helper.ml
+++ b/src/plugins/plugin_helper.ml
@@ -1,3 +1,19 @@
+(*
+Copyright (2010-2014) INCUBAID BVBA
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*)
+
 let serialize_string  b s = Llio.string_to b s
 let serialize_hashtbl b f h = Llio.hashtbl_to b f h
 let serialize_string_list b sl = Llio.string_list_to b sl

--- a/src/plugins/plugin_helper.mli
+++ b/src/plugins/plugin_helper.mli
@@ -1,4 +1,19 @@
-(* ... *)
+(*
+Copyright (2010-2014) INCUBAID BVBA
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*)
+
 
 val serialize_string  : Buffer.t -> string -> unit
 val serialize_hashtbl : Buffer.t -> (Buffer.t -> 'a -> 'b -> unit) ->

--- a/src/plugins/plugin_helper.mli
+++ b/src/plugins/plugin_helper.mli
@@ -1,0 +1,16 @@
+(* ... *)
+
+val serialize_string  : Buffer.t -> string -> unit
+val serialize_hashtbl : Buffer.t -> (Buffer.t -> 'a -> 'b -> unit) ->
+                        ('a, 'b) Hashtbl.t -> unit
+
+val serialize_string_list: Buffer.t -> string list -> unit
+
+type input
+val make_input : string -> int -> input
+
+val deserialize_string : input -> string
+val deserialize_hashtbl: input -> (input -> 'a * 'b) -> ('a, 'b) Hashtbl.t
+val deserialize_string_list: input -> string list
+
+val debug_f: ('a, unit, string, unit) format4 -> 'a

--- a/src/plugins/plugin_loader.ml
+++ b/src/plugins/plugin_loader.ml
@@ -19,6 +19,14 @@ open Lwt
 let section = Logger.Section.main
 
 let load home pnames =
+  (*let () = Dynlink.allow_only [
+               "Pervasives";
+               "Registry";
+               "Llio";
+               "Int32";
+             ]
+  in*)
+
   let rec _inner = function
     | [] -> Lwt.return ()
     | p :: ps ->
@@ -27,7 +35,16 @@ let load home pnames =
       let full = Filename.concat home pwe in
       let qual = Dynlink.adapt_filename full in
       Logger.info_f_ "qualified as: %s" qual >>= fun () ->
-      Dynlink.loadfile_private qual;
-      _inner ps
+      let msg =
+        try
+          let () = Dynlink.loadfile_private qual in
+          None
+        with Dynlink.Error e ->
+          let em = Dynlink.error_message e in
+          Some em
+      in
+      match msg with
+      | None -> _inner ps
+      | Some em -> failwith (Printf.sprintf "%s: Dynlink.Error %S" p em)
   in
   _inner pnames

--- a/src/plugins/plugin_loader.ml
+++ b/src/plugins/plugin_loader.ml
@@ -19,13 +19,18 @@ open Lwt
 let section = Logger.Section.main
 
 let load home pnames =
-  (*let () = Dynlink.allow_only [
+  (*
+    (* if you really want to turn on the screws,
+       and limit what they are allowed to do you can do
+       something like this: *)
+    let () = Dynlink.allow_only [
                "Pervasives";
                "Registry";
                "Llio";
                "Int32";
              ]
-  in*)
+  in
+  *)
 
   let rec _inner = function
     | [] -> Lwt.return ()


### PR DESCRIPTION
Plugins need to be able to (de)serialize inputs and outputs, but allowing them to access `Llio` opens up `Std` and explodes the number of dependencies. These dependencies make _plugins_ break if they are not compiled with the exact (md5 wise) same set of library versions as the arakoon binary.

The patch introduces an extra interface allowing them to not be dependent on kitchen sinks like `Lwt` or `Std`. 
As an example: 

```
ocamlobjinfo _build/plugin_find.cmo
File _build/plugin_find.cmo
Unit name: Plugin_find
Interfaces imported:
    ad06f04cfca6d404d1de76c3dc67324a    Int32
    d012329cc712e91d0f10a5eef2303d18    Printf
    db7f34081ef8fcaf499f19523d0736c6    String
    9b043210ba766ec98c0c64e3dfba3013    Plugin_find
    e2378c62e62b3516b3b9da1a984c728d    Plugin_helper
    af3ef6fba94cdb4eba31e98b4e341dab    Buffer
    024edc3512403b725052aec8e41ed971    Hashtbl
    b0adfa4175f86e4394859886c1a374bb    Obj
    36b5bc8227dc9914c6d9fd9bdcfadb45    Pervasives
    f11d7ddcffad09397202a49bd9bb4283    Map
    6c35bd33088907f850bc27cd9072ffb5    Registry
Uses unsafe features: no
Force link: no
```

While previously it would fe also depend on `Test_utils`, `Quickcheck` and some 40 others.
