### PR TITLE
log failure before exit

### DIFF
--- a/src/plugins/plugin_loader.ml
+++ b/src/plugins/plugin_loader.ml
@@ -50,6 +50,9 @@ let load home pnames =
       in
       match msg with
       | None -> _inner ps
-      | Some em -> failwith (Printf.sprintf "%s: Dynlink.Error %S" p em)
+      | Some em ->
+         let s = Printf.sprintf "%s: Dynlink.Error %S" p em in
+         Lwt_log.ign_fatal  s;
+         failwith s
   in
   _inner pnames


### PR DESCRIPTION
something like this 

```
Jan 13 09:27:13 0924: (main|fatal): nsm_host_plugin: Dynlink.Error "error loading shared library: /tmp/arakoon/arakoon_0/nsm_host_plugin.cmxs: undefined symbol: camlSlice"
```
