### PR TITLE
More tlx

### DIFF
--- a/pylabs/test/server/quick/system_tests_basic.py
+++ b/pylabs/test/server/quick/system_tests_basic.py
@@ -642,7 +642,7 @@ def test_close_on_sigterm():
     log_file = "/".join([cfg['log_dir'], n0 + ".log"])
     with open(log_file,'r') as f:
         lines = f.readlines()
-        tail = lines[-20:]
+        tail = lines[-40:]
         found = False
         for l in tail:
             print l

--- a/pylabs/test/server/system_tests_common.py
+++ b/pylabs/test/server/system_tests_common.py
@@ -717,7 +717,7 @@ def setup_n_nodes ( n, force_master, home_dir , extra = None,
 
     logging.info( "Starting cluster" )
     start_all( cluster_id )
-    time.sleep(1.0)
+    time.sleep(2.0)
 
     logging.info( "Setup complete" )
 

--- a/src/node/catchup.ml
+++ b/src/node/catchup.ml
@@ -129,9 +129,7 @@ let catchup_tlog (type s) ~tls_ctx ~stop other_configs ~cluster_id  mr_name ((mo
   let copy_tlog connection =
     make_remote_nodestream cluster_id connection >>= fun (client:nodestream) ->
     let f (i,value) =
-      tlog_coll # log_value_explicit i value
-                ~sync:false ~flush:false
-                None
+      tlog_coll # log_value_explicit i value ~sync:false None
       >>= fun _ ->
       stop_fuse stop
     in

--- a/src/node/catchup.ml
+++ b/src/node/catchup.ml
@@ -450,15 +450,22 @@ let last_entries2
 
           (* maybe stream a bit *)
           begin
-            let (-:) = Sn.sub
-            and (+:) = Sn.add
-            and (%:) = Sn.rem
+            let (-:)  = Sn.sub
+            and (+:)  = Sn.add
+            and (%:)  = Sn.rem
+            and (/:)  = Sn.div
+            and ( *:) = Sn.mul
             in
-            let next_rotation = start_i2 +: (step -: (start_i2 %: step)) in
+            let next_rotation =
+              ((start_i2 +: (step -: 1L)) /: step) *: step
+            in
             Logger.debug_f_ "next_rotation = %Li" next_rotation >>= fun () ->
-            (if next_rotation < too_far_i
+            (if start_i2 < next_rotation && next_rotation < too_far_i
              then
                begin
+                 Lwt_log.debug_f
+                   "streaming_entries ~start_i2:%Li ~next_rotation:%Li"
+                   start_i2 next_rotation >>= fun () ->
                  stream_entries start_i2 next_rotation >>= fun () ->
                  Lwt.return next_rotation
                end

--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -198,7 +198,7 @@ let only_catchup (type s) (module S : Store.STORE with type t = s) ~tls_ctx ~nam
        let compressor = me.compressor in
        make_tlog_coll ~compressor
                       me.tlog_dir me.tlx_dir me.head_dir
-                      ~fsync:me.fsync name ~fsync_tlog_dir:me._fsync_tlog_dir >>= fun tlc ->
+                      ~fsync:false name ~fsync_tlog_dir:false >>= fun tlc ->
        Catchup.catchup ~tls_ctx ~stop:(ref false)
                        me.Node_cfg.Node_cfg.node_name other_configs ~cluster_id
                        ((module S),store,tlc) mr_name >>= fun _ ->
@@ -333,7 +333,7 @@ module X = struct
     >>= fun () ->
     let sync = Value.is_synced v in
     let marker = (None:string option) in
-    tlog_coll # log_value_explicit i v sync marker >>= fun () ->
+    tlog_coll # log_value_explicit i v ~sync ~flush:true marker >>= fun () ->
     begin
       match v with
         | Value.Vc (us,_)     ->
@@ -368,7 +368,7 @@ let _main_2 (type s)
       make_tlog_coll
       make_config get_snapshot_name ~name
       ~daemonize ~catchup_only ~stop : int Lwt.t =
-  Lwt_io.set_default_buffer_size 32768;
+  Lwt_io.set_default_buffer_size (1 lsl 16);
   let cluster_cfg = make_config () in
   let cfgs = cluster_cfg.cfgs in
   let me, others = _split name cfgs in

--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -198,7 +198,8 @@ let only_catchup (type s) (module S : Store.STORE with type t = s) ~tls_ctx ~nam
        let compressor = me.compressor in
        make_tlog_coll ~compressor
                       me.tlog_dir me.tlx_dir me.head_dir
-                      ~fsync:false name ~fsync_tlog_dir:false >>= fun tlc ->
+                      ~fsync:me.fsync name ~fsync_tlog_dir:me._fsync_tlog_dir
+       >>= fun tlc ->
        Catchup.catchup ~tls_ctx ~stop:(ref false)
                        me.Node_cfg.Node_cfg.node_name other_configs ~cluster_id
                        ((module S),store,tlc) mr_name >>= fun _ ->
@@ -333,7 +334,7 @@ module X = struct
     >>= fun () ->
     let sync = Value.is_synced v in
     let marker = (None:string option) in
-    tlog_coll # log_value_explicit i v ~sync ~flush:true marker >>= fun () ->
+    tlog_coll # log_value_explicit i v ~sync marker >>= fun () ->
     begin
       match v with
         | Value.Vc (us,_)     ->

--- a/src/tlog/mem_tlogcollection.ml
+++ b/src/tlog/mem_tlogcollection.ml
@@ -70,14 +70,14 @@ class mem_tlog_collection _name =
 
     method which_tlog_file _start_i = failwith "which_tlog_file not supported"
 
-    method log_value_explicit i (v:Value.t) ~sync ~flush marker =
+    method log_value_explicit i (v:Value.t) ~sync marker =
       let entry = Entry.make i v 0L marker in
       let () = data <- entry::data in
       let () = last_entry <- (Some entry) in
       Lwt.return ()
 
     method log_value i v = self #log_value_explicit i v
-                                ~sync:false ~flush:false None
+                                ~sync:false None
 
     method dump_head _oc = Llio.lwt_failfmt "dump_head not implemented"
 

--- a/src/tlog/mem_tlogcollection.ml
+++ b/src/tlog/mem_tlogcollection.ml
@@ -70,13 +70,14 @@ class mem_tlog_collection _name =
 
     method which_tlog_file _start_i = failwith "which_tlog_file not supported"
 
-    method log_value_explicit i (v:Value.t) _sync marker =
+    method log_value_explicit i (v:Value.t) ~sync ~flush marker =
       let entry = Entry.make i v 0L marker in
       let () = data <- entry::data in
       let () = last_entry <- (Some entry) in
       Lwt.return ()
 
-    method log_value i v = self #log_value_explicit i v false None
+    method log_value i v = self #log_value_explicit i v
+                                ~sync:false ~flush:false None
 
     method dump_head _oc = Llio.lwt_failfmt "dump_head not implemented"
 
@@ -86,8 +87,8 @@ class mem_tlog_collection _name =
 
     method get_tlog_from_i _ = Sn.start
 
-    method close ?(wait_for_compression = false) () = 
-        let () = ignore wait_for_compression in 
+    method close ?(wait_for_compression = false) () =
+        let () = ignore wait_for_compression in
         Lwt.return ()
 
     method remove_oldest_tlogs _count = Lwt.return ()
@@ -96,8 +97,8 @@ class mem_tlog_collection _name =
   end
 
 let make_mem_tlog_collection _tlog_dir _tlf_dir _head_dir ~fsync name ~fsync_tlog_dir =
-  let () = ignore fsync in 
-  let () = ignore fsync_tlog_dir in 
+  let () = ignore fsync in
+  let () = ignore fsync_tlog_dir in
   let x = new mem_tlog_collection name in
   let x2 = (x :> tlog_collection) in
   Lwt.return x2

--- a/src/tlog/tlc2.ml
+++ b/src/tlog/tlc2.ml
@@ -513,10 +513,11 @@ class tlc2
              let p = F.file_pos file in
              let oc = F.oc_of file in
              Tlogcommon.write_entry oc i value >>= fun () ->
+             (* we need to flush here as iteration uses another file *)
+             Lwt_io.flush oc >>= fun () ->
              begin
                if sync && fsync
                then
-                 Lwt_io.flush oc >>= fun () ->
                  F.fsync file
                else Lwt.return ()
              end

--- a/src/tlog/tlogcollection.ml
+++ b/src/tlog/tlogcollection.ml
@@ -21,7 +21,9 @@ class type tlog_collection = object
   method validate_last_tlog: unit -> (tlogValidity * Entry.t option * Index.index) Lwt.t
   method iterate: Sn.t -> Sn.t -> (Entry.t -> unit Lwt.t) -> unit Lwt.t
   method log_value : Sn.t -> Value.t -> unit Lwt.t
-  method log_value_explicit : Sn.t -> Value.t -> bool -> string option -> unit Lwt.t
+  method log_value_explicit : Sn.t -> Value.t ->
+                              sync:bool -> flush:bool -> string option
+                              -> unit Lwt.t
   method get_last_i: unit -> Sn.t
   method get_last_value: Sn.t -> Value.t option (* Lwt.t *)
   method get_last: unit -> (Value.t * Sn.t) option

--- a/src/tlog/tlogcollection.ml
+++ b/src/tlog/tlogcollection.ml
@@ -22,8 +22,7 @@ class type tlog_collection = object
   method iterate: Sn.t -> Sn.t -> (Entry.t -> unit Lwt.t) -> unit Lwt.t
   method log_value : Sn.t -> Value.t -> unit Lwt.t
   method log_value_explicit : Sn.t -> Value.t ->
-                              sync:bool -> flush:bool -> string option
-                              -> unit Lwt.t
+                              sync:bool -> string option -> unit Lwt.t
   method get_last_i: unit -> Sn.t
   method get_last_value: Sn.t -> Value.t option (* Lwt.t *)
   method get_last: unit -> (Value.t * Sn.t) option

--- a/src/tlog/tlogcommon.ml
+++ b/src/tlog/tlogcommon.ml
@@ -118,7 +118,7 @@ let read_into ic buf =
 
 let entry_to buf i value =
   Sn.sn_to buf i;
-  let b = Buffer.create 64 in
+  let b = Buffer.create 256 in
   let () = Value.value_to b value in
   let cmd = Buffer.contents b in
   let crc = Crc32c.calculate_crc32c cmd 0 (String.length cmd) in
@@ -127,7 +127,7 @@ let entry_to buf i value =
 
 let write_entry oc i value =
   Sn.output_sn oc i >>= fun () ->
-  let b = Buffer.create 64 in
+  let b = Buffer.create 256 in
   let () = Value.value_to b value in
   let cmd = Buffer.contents b in
   let chksum = Crc32c.calculate_crc32c cmd 0 (String.length cmd) in


### PR DESCRIPTION
don't iterate over the first tlog after the head.db as it can be fetched in its entirety.
