### PR TITLE
Change behaviour of range like queries during transactions

### DIFF
--- a/src/node/store.ml
+++ b/src/node/store.ml
@@ -813,11 +813,12 @@ struct
           begin match assertion with
             | Range_assertion.ContainsExactly keys ->
               let _, keys' = prefix_keys store prefix (-1) in
-              let actual = List.map Key.get keys' in
+              let actual = List.rev_map Key.get keys' in
               if keys = actual
               then Lwt.return (Ok None)
               else Lwt.return (Update_fail(Arakoon_exc.E_ASSERTION_FAILED,
-                                           Range_assertion.to_string assertion))
+                                           Range_assertion.to_string assertion ^
+                                           " actual: " ^ (String.concat "," actual)))
           end
         | Update.AdminSet(k,vo) ->
           let () =

--- a/src/node/store.ml
+++ b/src/node/store.ml
@@ -813,9 +813,11 @@ struct
           begin match assertion with
             | Range_assertion.ContainsExactly keys ->
               let _, keys' = prefix_keys store prefix (-1) in
-              if keys = (List.map Key.get keys')
+              let actual = List.map Key.get keys' in
+              if keys = actual
               then Lwt.return (Ok None)
-              else Lwt.return (Update_fail(Arakoon_exc.E_ASSERTION_FAILED, prefix))
+              else Lwt.return (Update_fail(Arakoon_exc.E_ASSERTION_FAILED,
+                                           Range_assertion.to_string assertion))
           end
         | Update.AdminSet(k,vo) ->
           let () =

--- a/src/system/single.ml
+++ b/src/system/single.ml
@@ -380,7 +380,10 @@ let _assert_range (client:client) =
   assert_range_should_fail [prefix; prefix ^ "fsda"] >>= fun () ->
   client # set (prefix ^ "bla") "" >>= fun () ->
   assert_range_should_fail [] >>= fun () ->
-  assert_range [prefix ^ "bla"]
+  assert_range [prefix ^ "bla"] >>= fun () ->
+  client # set (prefix ^ "bla2") "" >>= fun () ->
+  assert_range [prefix ^ "bla"; prefix ^ "bla2"]
+
 
 let _range_1 (client: client) =
   let rec fill i =

--- a/src/tlog/update.ml
+++ b/src/tlog/update.ml
@@ -22,7 +22,8 @@ module Range_assertion = struct
     | ContainsExactly of string list
 
   let to_string = function
-    | ContainsExactly _ -> "ContainsExactly ..."
+    | ContainsExactly keys ->
+      Printf.sprintf "ContainsExactly [ %S ]" (String.concat "; " keys)
 
   let to_buffer buf = function
     | ContainsExactly ss ->


### PR DESCRIPTION
to fix a bug that could leave part of a transaction applied iso rolling back
- bugfix for the range_assertion
